### PR TITLE
Improve keyboard breathing and phone layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,15 +5,16 @@ from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel, QMainW
 class BreathCircle(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._radius = 80
-        self.min_radius = 80
-        self.max_radius = 200
+        self._radius = 60
+        self.min_radius = 60
+        self.max_radius = 140
         self.inhale_time = 4000  # milliseconds
         self.exhale_time = 6000  # milliseconds
         self.increment = 50      # milliseconds per phase after each cycle
         self.animation = None
         self.phase = 'idle'
         self.breath_count = 0
+        self.cycle_valid = False
         self.count_changed_callback = None
         self.setMinimumSize(self.max_radius * 2 + 20, self.max_radius * 2 + 20)
 
@@ -38,11 +39,13 @@ class BreathCircle(QWidget):
         if self.phase != 'idle':
             return
         self.phase = 'inhaling'
+        self.cycle_valid = False
         self.animate(self._radius, self.max_radius, self.inhale_time)
 
     def start_exhale(self):
         if self.phase != 'inhaling':
             return
+        self.cycle_valid = self._radius >= self.max_radius - 1
         self.phase = 'exhaling'
         self.animate(self._radius, self.min_radius, self.exhale_time)
 
@@ -59,11 +62,12 @@ class BreathCircle(QWidget):
 
     def animation_finished(self):
         if self.phase == 'exhaling':
-            self.breath_count += 1
-            if self.count_changed_callback:
-                self.count_changed_callback(self.breath_count)
-            self.inhale_time += self.increment
-            self.exhale_time += self.increment
+            if self.cycle_valid:
+                self.breath_count += 1
+                if self.count_changed_callback:
+                    self.count_changed_callback(self.breath_count)
+                self.inhale_time += self.increment
+                self.exhale_time += self.increment
             self.phase = 'idle'
         elif self.phase == 'inhaling':
             # Wait for release to exhale
@@ -87,13 +91,13 @@ class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Calmio")
-        self.resize(1280, 720)
+        self.resize(360, 640)
 
         self.circle = BreathCircle()
         self.circle.count_changed_callback = self.update_count
 
         font = QFont()
-        font.setPointSize(32)
+        font.setPointSize(24)
         font.setBold(True)
         self.label = QLabel("0")
         self.label.setAlignment(Qt.AlignCenter)
@@ -112,14 +116,14 @@ class MainWindow(QMainWindow):
         self.label.setText(str(count))
 
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key_Space:
+        if event.key() == Qt.Key_Space and not event.isAutoRepeat():
             self.circle.start_inhale()
             event.accept()
         else:
             super().keyPressEvent(event)
 
     def keyReleaseEvent(self, event):
-        if event.key() == Qt.Key_Space:
+        if event.key() == Qt.Key_Space and not event.isAutoRepeat():
             self.circle.start_exhale()
             event.accept()
         else:


### PR DESCRIPTION
## Summary
- tweak circle size for smaller screens
- ignore auto-repeat key events
- only count full inhale+exhale cycles
- shrink window and font for phone-sized view

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c094eaa4832bb7fa8555d44fd6f5