### PR TITLE
Fix closing issue on Windows

### DIFF
--- a/run_app.bat
+++ b/run_app.bat
@@ -9,3 +9,6 @@ git pull
 pip install -r requirements.txt
 
 python main.py
+echo.
+echo App exited with code %ERRORLEVEL%.
+pause


### PR DESCRIPTION
## Summary
- keep the command window open after running `main.py` so errors can be seen

## Testing
- `python main.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6843d99ddb8c832bb8a5005a10a7e802