### PR TITLE
Fix missing QPushButton import

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,13 @@
 from PySide6.QtCore import Qt, Property, QPropertyAnimation, QEasingCurve, QParallelAnimationGroup
 from PySide6.QtGui import QPainter, QBrush, QColor, QFont, QRadialGradient
-from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel, QMainWindow
+from PySide6.QtWidgets import (
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+)
 
 class BreathCircle(QWidget):
     def __init__(self, parent=None):


### PR DESCRIPTION
## Summary
- import `QPushButton` alongside the other widgets

## Testing
- `python -m py_compile main.py`
- `pip install PySide6`
- `QT_QPA_PLATFORM=offscreen python main.py` *(fails: libEGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dae51d70832b881f289879684668