### PR TITLE
Improve session detail tracking

### DIFF
--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -6,7 +6,7 @@ from datetime import datetime
 class DataStore:
     def __init__(self, path="calmio_data.json"):
         self.path = Path(path)
-        self.data = {"daily_minutes": {}, "last_session": {}}
+        self.data = {"daily_seconds": {}, "last_session": {}}
         self.load()
 
     def load(self):
@@ -14,6 +14,10 @@ class DataStore:
             try:
                 with self.path.open("r", encoding="utf-8") as f:
                     self.data.update(json.load(f))
+                    if "daily_minutes" in self.data:
+                        self.data["daily_seconds"] = {
+                            k: v * 60 for k, v in self.data.pop("daily_minutes").items()
+                        }
             except (json.JSONDecodeError, IOError):
                 pass
 
@@ -21,22 +25,23 @@ class DataStore:
         with self.path.open("w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2)
 
-    def add_session(self, start_dt, minutes, breaths, last_cycle):
+    def add_session(self, start_dt, seconds, breaths, inhale, exhale):
         date_key = start_dt.date().isoformat()
-        self.data["daily_minutes"][date_key] = (
-            self.data["daily_minutes"].get(date_key, 0) + minutes
+        self.data["daily_seconds"][date_key] = (
+            self.data["daily_seconds"].get(date_key, 0) + seconds
         )
         self.data["last_session"] = {
-            "start": start_dt.strftime("%Y-%m-%d %H:%M"),
-            "minutes": minutes,
+            "start": start_dt.strftime("%Y-%m-%d %H:%M:%S"),
+            "duration": seconds,
             "breaths": breaths,
-            "last_cycle": last_cycle,
+            "last_inhale": inhale,
+            "last_exhale": exhale,
         }
         self.save()
 
-    def get_today_minutes(self):
+    def get_today_seconds(self):
         today_key = datetime.now().date().isoformat()
-        return self.data["daily_minutes"].get(today_key, 0)
+        return self.data["daily_seconds"].get(today_key, 0)
 
     def get_last_session(self):
         return self.data.get("last_session", {})

--- a/calmio/progress_circle.py
+++ b/calmio/progress_circle.py
@@ -6,12 +6,13 @@ from PySide6.QtWidgets import QWidget
 class ProgressCircle(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.minutes = 0
-        self.goal_step = 30
+        self.seconds = 0
+        # goal_step expressed in seconds (30 minute cycle)
+        self.goal_step = 30 * 60
         self.setMinimumSize(220, 220)
 
-    def set_minutes(self, m):
-        self.minutes = m
+    def set_seconds(self, s):
+        self.seconds = s
         self.update()
 
     def paintEvent(self, event):
@@ -25,9 +26,13 @@ class ProgressCircle(QWidget):
         painter.setPen(base_pen)
         painter.drawArc(rect, 0, 360 * 16)
 
-        progress = (self.minutes % self.goal_step) / self.goal_step
+        progress = (self.seconds % self.goal_step) / self.goal_step
         painter.setPen(progress_pen)
         painter.drawArc(rect, 90 * 16, int(-360 * 16 * progress))
+        painter.setPen(Qt.NoPen)
+        fill_color = QColor(255, 204, 188, 80)
+        painter.setBrush(fill_color)
+        painter.drawPie(rect, 90 * 16, int(-360 * 16 * progress))
 
         painter.setPen(Qt.NoPen)
         painter.setBrush(Qt.NoBrush)
@@ -36,12 +41,12 @@ class ProgressCircle(QWidget):
         font.setPointSize(14)
         painter.setFont(font)
         painter.setPen(QColor("#444"))
-        center_text = f"{self.minutes} min\nmeditated"
+        center_text = f"{int(self.seconds // 60)} min\nmeditated"
         painter.drawText(self.rect(), Qt.AlignCenter, center_text)
 
-        base = (self.minutes // self.goal_step) * self.goal_step
+        base = (int(self.seconds // 60) // (self.goal_step // 60)) * (self.goal_step // 60)
         labels = {
-            "top": base + self.goal_step,
+            "top": base + (self.goal_step // 60),
             "right": base + 10,
             "left": base + 20,
         }
@@ -51,7 +56,7 @@ class ProgressCircle(QWidget):
         painter.setFont(label_font)
         painter.drawText(
             rect.center().x() - 10,
-            rect.top() - 5,
+            rect.top() - 15,
             f"{labels['top']} min",
         )
         painter.drawText(

--- a/calmio/session_complete.py
+++ b/calmio/session_complete.py
@@ -61,16 +61,18 @@ class SessionComplete(QWidget):
             row_widget.setLayout(row_layout)
             return row_widget, lbl
 
-        self.duration_row, self.duration_lbl = row("\u23F1 Duration: 0 min")
-        self.breaths_row, self.breaths_lbl = row("\u1F4A8 Breaths: 0")
-        self.longest_row, self.longest_lbl = row("\u23F2 Longest breath: 0s")
+        self.duration_row, self.duration_lbl = row("\u23F1 Duration: 0s")
+        self.breaths_row, self.breaths_lbl = row("\U0001FAC1 Breaths: 0")
+        self.inhale_row, self.inhale_lbl = row("\u2B06\ufe0f Inhale: 0.00s")
+        self.exhale_row, self.exhale_lbl = row("\u2B07\ufe0f Exhale: 0.00s")
         self.start_row, self.start_lbl = row("\u23F0 Start time: --")
         self.end_row, self.end_lbl = row("\u23F0 End time: --")
 
         for rw in (
             self.duration_row,
             self.breaths_row,
-            self.longest_row,
+            self.inhale_row,
+            self.exhale_row,
             self.start_row,
             self.end_row,
         ):
@@ -95,10 +97,17 @@ class SessionComplete(QWidget):
         self.done_btn.clicked.connect(self.done.emit)
         layout.addWidget(self.done_btn, alignment=Qt.AlignCenter)
 
-    def set_stats(self, duration, breaths, longest, start, end):
-        self.duration_lbl.setText(f"\u23F1 Duration: {duration} min")
-        self.breaths_lbl.setText(f"\U0001F4A8 Breaths: {breaths}")
-        self.longest_lbl.setText(f"\u23F2 Longest breath: {longest}s")
+    def set_stats(self, duration, breaths, inhale, exhale, start, end):
+        if duration < 60:
+            self.duration_lbl.setText(f"\u23F1 Duration: {duration:.0f}s")
+        else:
+            m = int(duration // 60)
+            s = int(duration % 60)
+            dur_str = f"{m}m" + (f" {s}s" if s else "")
+            self.duration_lbl.setText(f"\u23F1 Duration: {dur_str}")
+        self.breaths_lbl.setText(f"\U0001FAC1 Breaths: {breaths}")
+        self.inhale_lbl.setText(f"\u2B06\ufe0f Inhale: {inhale:.2f}s")
+        self.exhale_lbl.setText(f"\u2B07\ufe0f Exhale: {exhale:.2f}s")
         self.start_lbl.setText(f"\u23F0 Start time: {start}")
         self.end_lbl.setText(f"\u23F0 End time: {end}")
 

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -25,12 +25,23 @@ class StatsOverlay(QWidget):
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(20)
 
+        header_layout = QHBoxLayout()
+        self.back_btn = QPushButton("\u2190")
+        self.back_btn.setStyleSheet(
+            "QPushButton{background:none;border:none;font-size:18px;}"
+        )
+        header_layout.addWidget(self.back_btn, alignment=Qt.AlignLeft)
+
         title = QLabel("Today's Meditation", self)
         title_font = QFont("Sans Serif")
         title_font.setPointSize(20)
         title_font.setWeight(QFont.Medium)
         title.setFont(title_font)
         title.setAlignment(Qt.AlignCenter)
+        header_layout.addWidget(title, alignment=Qt.AlignCenter)
+        header_layout.addStretch()
+        layout.addLayout(header_layout)
+        self.back_btn.clicked.connect(self.on_back)
 
         self.progress = ProgressCircle(self)
 
@@ -94,7 +105,6 @@ class StatsOverlay(QWidget):
         nav_layout.addWidget(self.week_btn)
         nav_layout.addWidget(self.month_btn)
 
-        layout.addWidget(title)
         layout.addWidget(self.progress, alignment=Qt.AlignCenter)
         layout.addWidget(streak_card, alignment=Qt.AlignCenter)
         layout.addWidget(self.sessions_btn, alignment=Qt.AlignCenter)
@@ -102,10 +112,23 @@ class StatsOverlay(QWidget):
         layout.addStretch()
         layout.addLayout(nav_layout)
 
-    def update_minutes(self, m):
-        self.progress.set_minutes(m)
+    def update_minutes(self, seconds):
+        self.progress.set_seconds(seconds)
 
-    def update_last_session(self, start, minutes, breaths, last_cycle):
+    def update_last_session(self, start, duration, breaths, inhale, exhale):
+        if duration < 60:
+            dur_str = f"{duration:.0f}s"
+        else:
+            m = int(duration // 60)
+            s = int(duration % 60)
+            dur_str = f"{m}m" + (f" {s}s" if s else "")
         self.ls_text.setText(
-            f"{start} \u2022 {minutes}min \u2022 {breaths} br \u2022 {last_cycle}s last"
+            f"\u23F0 {start} \u2022 \u23F1 {dur_str} \u2022 \U0001FAC1 {breaths} \u2022 \u2B06\uFE0F {inhale:.2f}s \u2B07\uFE0F {exhale:.2f}s"
         )
+
+    def on_back(self):
+        parent = self.parent()
+        if hasattr(parent, "close_stats"):
+            parent.close_stats()
+        else:
+            self.hide()


### PR DESCRIPTION
## Summary
- track progress circle by seconds and store in JSON
- record inhale and exhale durations for last breath
- display session seconds if under a minute
- add back button to stats overlay
- hide menu when ending session

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843e89f5574832b8fc9b1b7aa82eb93