### PR TITLE
Improve streak tracking and UI layout

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -114,6 +114,7 @@ class MainWindow(QMainWindow):
                 last.get("last_inhale", 0),
                 last.get("last_exhale", 0),
             )
+        self.stats_overlay.update_streak(self.data_store.get_streak())
 
         self.position_buttons()
 
@@ -165,6 +166,7 @@ class MainWindow(QMainWindow):
             end_time_str,
         )
         self.stack.setCurrentWidget(self.session_complete)
+        self.stats_overlay.update_streak(self.data_store.get_streak())
         for btn in (self.options_button, self.stats_button, self.end_button):
             btn.hide()
 
@@ -198,7 +200,10 @@ class MainWindow(QMainWindow):
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.MouseButtonPress:
-            pos = self.mapFromGlobal(event.globalPosition().toPoint())
+            if hasattr(event, "globalPosition"):
+                pos = self.mapFromGlobal(event.globalPosition().toPoint())
+            else:
+                pos = self.mapFromGlobal(event.globalPos())
             if not (
                 self.menu_button.geometry().contains(pos)
                 or self.options_button.geometry().contains(pos)
@@ -253,10 +258,16 @@ class MainWindow(QMainWindow):
         self.stack.setCurrentWidget(self.main_view)
         self.stats_overlay.show()
         self.stats_overlay.raise_()
+        self.circle.breath_count = 0
+        self.label.setText("0")
+        self.session_seconds = 0
         for btn in (self.options_button, self.stats_button, self.end_button):
             btn.hide()
 
     def on_session_complete_closed(self):
         self.stack.setCurrentWidget(self.main_view)
+        self.circle.breath_count = 0
+        self.label.setText("0")
+        self.session_seconds = 0
         for btn in (self.options_button, self.stats_button, self.end_button):
             btn.hide()

--- a/calmio/progress_circle.py
+++ b/calmio/progress_circle.py
@@ -41,7 +41,25 @@ class ProgressCircle(QWidget):
         font.setPointSize(14)
         painter.setFont(font)
         painter.setPen(QColor("#444"))
-        center_text = f"{int(self.seconds // 60)} min\nmeditated"
+
+        if self.seconds < 60:
+            time_str = f"{int(self.seconds)}s"
+        elif self.seconds < 3600:
+            m = int(self.seconds // 60)
+            s = int(self.seconds % 60)
+            time_str = f"{m}m" + (f" {s}s" if s else "")
+        else:
+            h = int(self.seconds // 3600)
+            m = int((self.seconds % 3600) // 60)
+            s = int(self.seconds % 60)
+            parts = [f"{h}h"]
+            if m:
+                parts.append(f"{m}m")
+            if s:
+                parts.append(f"{s}s")
+            time_str = " ".join(parts)
+
+        center_text = f"{time_str}\nmeditados"
         painter.drawText(self.rect(), Qt.AlignCenter, center_text)
 
         base = (int(self.seconds // 60) // (self.goal_step // 60)) * (self.goal_step // 60)

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -45,7 +45,7 @@ class StatsOverlay(QWidget):
 
         self.progress = ProgressCircle(self)
 
-        self.streak_label = QLabel("\ud83d\udd25 3 days in a row", self)
+        self.streak_label = QLabel("\ud83d\udd25 1 d\u00eda consecutivo", self)
         streak_font = QFont("Sans Serif")
         streak_font.setPointSize(12)
         self.streak_label.setFont(streak_font)
@@ -70,14 +70,17 @@ class StatsOverlay(QWidget):
 
         self.last_session = QFrame()
         self.last_session.setStyleSheet(
-            "background:white;border-radius:15px;padding:10px;"
+            "background:#E0F0FF;border-radius:15px;padding:6px;"
         )
         ls_shadow = QGraphicsDropShadowEffect(self)
         ls_shadow.setBlurRadius(8)
         ls_shadow.setOffset(0, 2)
         self.last_session.setGraphicsEffect(ls_shadow)
         ls_layout = QHBoxLayout(self.last_session)
+        ls_layout.setContentsMargins(6, 2, 6, 2)
         self.ls_text = QLabel("")
+        self.ls_text.setAlignment(Qt.AlignLeft)
+        self.ls_text.setWordWrap(True)
         ls_tag = QLabel("Last session")
         ls_tag.setStyleSheet(
             "background:#eee;border-radius:10px;padding:2px 6px;"
@@ -111,6 +114,13 @@ class StatsOverlay(QWidget):
         layout.addWidget(self.last_session)
         layout.addStretch()
         layout.addLayout(nav_layout)
+
+    def update_streak(self, days):
+        if days == 1:
+            text = "\ud83d\udd25 1 d\u00eda consecutivo"
+        else:
+            text = f"\ud83d\udd25 {days} d\u00edas consecutivos"
+        self.streak_label.setText(text)
 
     def update_minutes(self, seconds):
         self.progress.set_seconds(seconds)


### PR DESCRIPTION
## Summary
- display meditated time in Spanish with seconds, minutes and hours
- tint "Last session" card blue and allow wrapped text
- show streak in Spanish and store streak in `DataStore`
- reset breath counter when leaving the session summary
- fix event filter to close menu when clicking outside

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843eb675170832b94c76fe7ce4228b2