### PR TITLE
Update session details to show full cycle duration

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -17,7 +17,8 @@ class BreathCircle(QWidget):
         self.exhale_time = 6000
         # Increase breathing times more gradually
         # Third inhale should be around 4.3 seconds (150ms per cycle)
-        self.increment = 150
+        # Reduce progression speed by half
+        self.increment = 75
         self.animation = None
         self.phase = 'idle'
         self.breath_count = 0

--- a/calmio/session_details.py
+++ b/calmio/session_details.py
@@ -46,8 +46,14 @@ class BreathGraph(QWidget):
         else:
             self.values = [float(v) for v in self.cycles]
         if self.values:
-            self.start_label = f"Inicio: {self.values[1]:.2f}s"
-            self.end_label = f"\u00DAltima: {self.values[-2]:.2f}s"
+            if self.cycles and isinstance(self.cycles[0], dict):
+                start_dur = self.cycles[0].get("inhale", 0) + self.cycles[0].get("exhale", 0)
+                end_dur = self.cycles[-1].get("inhale", 0) + self.cycles[-1].get("exhale", 0)
+            else:
+                start_dur = self.values[1] if len(self.values) > 3 else 0
+                end_dur = self.values[-2] if len(self.values) > 3 else 0
+            self.start_label = f"Inicio: {start_dur:.2f}s"
+            self.end_label = f"\u00DAltima: {end_dur:.2f}s"
         self.update()
 
     def _smooth_path(self, pts):
@@ -224,12 +230,10 @@ class SessionDetailsView(QWidget):
                 }
             ]
 
-        first_inhale = (
-            cycles[0].get("inhale", 0) if cycles and isinstance(cycles[0], dict) else 0
-        )
-        last_exhale = (
-            cycles[-1].get("exhale", 0) if cycles and isinstance(cycles[-1], dict) else 0
-        )
+        first_cycle = cycles[0] if cycles and isinstance(cycles[0], dict) else {}
+        last_cycle = cycles[-1] if cycles and isinstance(cycles[-1], dict) else {}
+        first_duration = first_cycle.get("inhale", 0) + first_cycle.get("exhale", 0)
+        last_duration = last_cycle.get("inhale", 0) + last_cycle.get("exhale", 0)
 
         if duration < 60:
             dur_str = f"{duration:.0f}s"
@@ -241,8 +245,8 @@ class SessionDetailsView(QWidget):
         self.start_lbl.setText(start)
         self.dur_lbl.setText(dur_str)
         self.breath_lbl.setText(str(breaths))
-        self.first_lbl.setText(f"{first_inhale:.2f}s")
-        self.last_lbl.setText(f"{last_exhale:.2f}s")
+        self.first_lbl.setText(f"{first_duration:.2f}s")
+        self.last_lbl.setText(f"{last_duration:.2f}s")
         self.tag_lbl.setVisible(is_last)
 
         self.graph.set_cycles(cycles)

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -147,8 +147,18 @@ class StatsOverlay(QWidget):
             m = int(duration // 60)
             s = int(duration % 60)
             dur_str = f"{m}m" + (f" {s}s" if s else "")
+        first_cycle = (cycles[0] if cycles and isinstance(cycles[0], dict) else None)
+        last_cycle = (cycles[-1] if cycles and isinstance(cycles[-1], dict) else None)
+        if first_cycle:
+            first_dur = first_cycle.get("inhale", 0) + first_cycle.get("exhale", 0)
+        else:
+            first_dur = inhale + exhale
+        if last_cycle:
+            last_dur = last_cycle.get("inhale", 0) + last_cycle.get("exhale", 0)
+        else:
+            last_dur = inhale + exhale
         self.ls_text.setText(
-            f"\u23F0 {start} \u2022 \u23F1 {dur_str} \u2022 \U0001FAC1 {breaths} \u2022 \u2B06\uFE0F {inhale:.2f}s \u2B07\uFE0F {exhale:.2f}s"
+            f"\u23F0 {start} \u2022 \u23F1 {dur_str} \u2022 \U0001FAC1 {breaths} \u2022 \u2B06\uFE0F {first_dur:.2f}s \u2B07\uFE0F {last_dur:.2f}s"
         )
 
     def on_back(self):

--- a/calmio/today_sessions.py
+++ b/calmio/today_sessions.py
@@ -97,6 +97,17 @@ class TodaySessionsView(QWidget):
         breaths = s.get("breaths", 0)
         inhale = s.get("last_inhale", 0.0)
         exhale = s.get("last_exhale", 0.0)
+        cycles = s.get("cycles", [])
+        first_cycle = cycles[0] if cycles and isinstance(cycles[0], dict) else None
+        last_cycle = cycles[-1] if cycles and isinstance(cycles[-1], dict) else None
+        if first_cycle:
+            first_dur = first_cycle.get("inhale", 0) + first_cycle.get("exhale", 0)
+        else:
+            first_dur = inhale + exhale
+        if last_cycle:
+            last_dur = last_cycle.get("inhale", 0) + last_cycle.get("exhale", 0)
+        else:
+            last_dur = inhale + exhale
         if duration < 60:
             dur_str = f"{duration:.0f}s"
         else:
@@ -106,6 +117,6 @@ class TodaySessionsView(QWidget):
         return (
             f"\u23F0 {start} \u2022 \u23F1 {dur_str} "
             f"\u2022 \U0001FAC1 {breaths} "
-            f"\u2022 \u2B06\uFE0F {inhale:.2f}s \u2B07\uFE0F {exhale:.2f}s"
+            f"\u2022 \u2B06\uFE0F {first_dur:.2f}s \u2B07\uFE0F {last_dur:.2f}s"
         )
 


### PR DESCRIPTION
## Summary
- show duration of first and last breathing cycles instead of separate inhale/exhale values
- slow down breathing progression increment

## Testing
- `python -m py_compile calmio/breath_circle.py calmio/session_details.py calmio/stats_overlay.py calmio/today_sessions.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f9672038832bb85441136d19cf52