### PR TITLE
Fix header overlap with progress circle top label

### DIFF
--- a/calmio/progress_circle.py
+++ b/calmio/progress_circle.py
@@ -74,7 +74,7 @@ class ProgressCircle(QWidget):
         painter.setFont(label_font)
         painter.drawText(
             rect.center().x() - 10,
-            rect.top() - 15,
+            rect.top() + 5,
             f"{labels['top']} min",
         )
         painter.drawText(


### PR DESCRIPTION
## Summary
- shift top label inside progress circle so it doesn't clash with "Today's Meditation"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843fd00cd14832bb5491117265d8797