### PR TITLE
Translate UI labels to Spanish and improve weekly stats

### DIFF
--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -114,6 +114,7 @@ class DataStore:
 
         longest_secs = 0
         longest_day = ""
+        longest_time = ""
         for s in self.data.get("sessions", []):
             try:
                 dt = datetime.fromisoformat(s.get("start", ""))
@@ -123,7 +124,18 @@ class DataStore:
                 dur = s.get("duration", 0)
                 if dur > longest_secs:
                     longest_secs = dur
-                    longest_day = dt.strftime("%A")
+                    eng_day = dt.strftime("%A")
+                    day_map = {
+                        "Monday": "Lunes",
+                        "Tuesday": "Martes",
+                        "Wednesday": "Mi\u00e9rcoles",
+                        "Thursday": "Jueves",
+                        "Friday": "Viernes",
+                        "Saturday": "S\u00e1bado",
+                        "Sunday": "Domingo",
+                    }
+                    longest_day = day_map.get(eng_day, eng_day)
+                    longest_time = dt.strftime("%H:%M")
 
         average = (total_seconds / 60) / 7 if total_seconds else 0
         return {
@@ -131,5 +143,6 @@ class DataStore:
             "total": total_seconds / 60,
             "average": average,
             "longest_day": longest_day,
+            "longest_time": longest_time,
             "longest_minutes": longest_secs / 60,
         }

--- a/calmio/session_complete.py
+++ b/calmio/session_complete.py
@@ -25,7 +25,7 @@ class SessionComplete(QWidget):
         layout.setSpacing(20)
 
         header_layout = QHBoxLayout()
-        title = QLabel("Session Complete")
+        title = QLabel("Sesi\u00f3n completada")
         title_font = QFont("Sans Serif")
         title_font.setPointSize(24)
         title_font.setWeight(QFont.Medium)
@@ -61,12 +61,12 @@ class SessionComplete(QWidget):
             row_widget.setLayout(row_layout)
             return row_widget, lbl
 
-        self.duration_row, self.duration_lbl = row("\u23F1 Duration: 0s")
-        self.breaths_row, self.breaths_lbl = row("\U0001FAC1 Breaths: 0")
-        self.inhale_row, self.inhale_lbl = row("\u2B06\ufe0f Inhale: 0.00s")
-        self.exhale_row, self.exhale_lbl = row("\u2B07\ufe0f Exhale: 0.00s")
-        self.start_row, self.start_lbl = row("\u23F0 Start time: --")
-        self.end_row, self.end_lbl = row("\u23F0 End time: --")
+        self.duration_row, self.duration_lbl = row("\u23F1 Duraci\u00f3n: 0s")
+        self.breaths_row, self.breaths_lbl = row("\U0001FAC1 Respiraciones: 0")
+        self.inhale_row, self.inhale_lbl = row("\u2B06\ufe0f Inhalar: 0.00s")
+        self.exhale_row, self.exhale_lbl = row("\u2B07\ufe0f Exhalar: 0.00s")
+        self.start_row, self.start_lbl = row("\u23F0 Inicio: --")
+        self.end_row, self.end_lbl = row("\u23F0 Fin: --")
 
         for rw in (
             self.duration_row,
@@ -80,7 +80,7 @@ class SessionComplete(QWidget):
 
         layout.addWidget(card)
 
-        self.phrase = QLabel("Take this calm with you into the day.")
+        self.phrase = QLabel("Lleva esta calma contigo durante el d\u00eda.")
         ph_font = QFont("Sans Serif")
         ph_font.setPointSize(12)
         self.phrase.setFont(ph_font)
@@ -88,7 +88,7 @@ class SessionComplete(QWidget):
         self.phrase.setStyleSheet("color:#666;")
         layout.addWidget(self.phrase)
 
-        self.done_btn = QPushButton("Done")
+        self.done_btn = QPushButton("Listo")
         self.done_btn.setStyleSheet(
             "QPushButton{"
             "background-color:#4D9FFF;border:none;border-radius:20px;"
@@ -99,15 +99,15 @@ class SessionComplete(QWidget):
 
     def set_stats(self, duration, breaths, inhale, exhale, start, end):
         if duration < 60:
-            self.duration_lbl.setText(f"\u23F1 Duration: {duration:.0f}s")
+            self.duration_lbl.setText(f"\u23F1 Duraci\u00f3n: {duration:.0f}s")
         else:
             m = int(duration // 60)
             s = int(duration % 60)
             dur_str = f"{m}m" + (f" {s}s" if s else "")
-            self.duration_lbl.setText(f"\u23F1 Duration: {dur_str}")
-        self.breaths_lbl.setText(f"\U0001FAC1 Breaths: {breaths}")
-        self.inhale_lbl.setText(f"\u2B06\ufe0f Inhale: {inhale:.2f}s")
-        self.exhale_lbl.setText(f"\u2B07\ufe0f Exhale: {exhale:.2f}s")
-        self.start_lbl.setText(f"\u23F0 Start time: {start}")
-        self.end_lbl.setText(f"\u23F0 End time: {end}")
+            self.duration_lbl.setText(f"\u23F1 Duraci\u00f3n: {dur_str}")
+        self.breaths_lbl.setText(f"\U0001FAC1 Respiraciones: {breaths}")
+        self.inhale_lbl.setText(f"\u2B06\ufe0f Inhalar: {inhale:.2f}s")
+        self.exhale_lbl.setText(f"\u2B07\ufe0f Exhalar: {exhale:.2f}s")
+        self.start_lbl.setText(f"\u23F0 Inicio: {start}")
+        self.end_lbl.setText(f"\u23F0 Fin: {end}")
 

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -37,13 +37,13 @@ class StatsOverlay(QWidget):
         )
         header_layout.addWidget(self.back_btn, alignment=Qt.AlignLeft)
 
-        title = QLabel("Today's Meditation", self)
+        self.title = QLabel("Meditaci\u00f3n de hoy", self)
         title_font = QFont("Sans Serif")
         title_font.setPointSize(20)
         title_font.setWeight(QFont.Medium)
-        title.setFont(title_font)
-        title.setAlignment(Qt.AlignCenter)
-        header_layout.addWidget(title, alignment=Qt.AlignCenter)
+        self.title.setFont(title_font)
+        self.title.setAlignment(Qt.AlignCenter)
+        header_layout.addWidget(self.title, alignment=Qt.AlignCenter)
         header_layout.addStretch()
         layout.addLayout(header_layout)
         self.back_btn.clicked.connect(self.on_back)
@@ -66,7 +66,7 @@ class StatsOverlay(QWidget):
         streak_layout = QHBoxLayout(streak_card)
         streak_layout.addWidget(self.streak_label, alignment=Qt.AlignCenter)
 
-        self.sessions_btn = QPushButton("View Sessions")
+        self.sessions_btn = QPushButton("Ver sesiones")
         self.sessions_btn.setStyleSheet(
             "QPushButton{"
             "background-color:#CCE4FF;border:none;border-radius:20px;"
@@ -88,7 +88,7 @@ class StatsOverlay(QWidget):
         self.ls_text = QLabel("")
         self.ls_text.setAlignment(Qt.AlignLeft)
         self.ls_text.setWordWrap(True)
-        ls_tag = QLabel("Last session")
+        ls_tag = QLabel("\u00daltima sesi\u00f3n")
         ls_tag.setStyleSheet(
             "background:#eee;border-radius:10px;padding:2px 6px;"
             "font-size:10px;color:#777;"
@@ -118,9 +118,9 @@ class StatsOverlay(QWidget):
         self.content_stack.addWidget(self.month_placeholder)
 
         nav_layout = QHBoxLayout()
-        self.today_btn = QPushButton("Today")
-        self.week_btn = QPushButton("Week")
-        self.month_btn = QPushButton("Month")
+        self.today_btn = QPushButton("Hoy")
+        self.week_btn = QPushButton("Semana")
+        self.month_btn = QPushButton("Mes")
         btn_style = (
             "QPushButton{background:white;border-radius:15px;"
             "padding:8px 16px;color:#777;}"
@@ -210,6 +210,12 @@ class StatsOverlay(QWidget):
                 )
         if index == 1:
             self.refresh_week()
+        if index == 0:
+            self.title.setText("Meditaci\u00f3n de hoy")
+        elif index == 1:
+            self.title.setText("Estad\u00edsticas semanales")
+        else:
+            self.title.setText("Estad\u00edsticas mensuales")
 
     def refresh_week(self):
         store = getattr(self.parent(), "data_store", None)
@@ -221,5 +227,6 @@ class StatsOverlay(QWidget):
             data["total"],
             data["average"],
             data["longest_day"],
+            data.get("longest_time", ""),
             data["longest_minutes"],
         )

--- a/calmio/weekly_stats.py
+++ b/calmio/weekly_stats.py
@@ -9,7 +9,7 @@ class WeeklyBarGraph(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.minutes = [0] * 7
-        self.days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+        self.days = ["Lun", "Mar", "Mi\u00e9", "Jue", "Vie", "S\u00e1b", "Dom"]
         self.setMinimumHeight(200)
 
     def set_minutes(self, minutes):
@@ -65,9 +65,9 @@ class WeeklyStatsView(QWidget):
         self.graph = WeeklyBarGraph(self)
         layout.addWidget(self.graph)
 
-        self.total_lbl = QLabel("Total this week: 0 min")
-        self.avg_lbl = QLabel("Daily average: 0 min")
-        self.longest_lbl = QLabel("Longest session: --")
+        self.total_lbl = QLabel("Total esta semana: 0 min")
+        self.avg_lbl = QLabel("Promedio diario: 0 min")
+        self.longest_lbl = QLabel("Sesi\u00f3n m\u00e1s larga: --")
 
         for lbl in (self.total_lbl, self.avg_lbl, self.longest_lbl):
             font = QFont("Sans Serif")
@@ -77,13 +77,13 @@ class WeeklyStatsView(QWidget):
             lbl.setAlignment(Qt.AlignCenter)
             layout.addWidget(lbl)
 
-    def set_stats(self, minutes_per_day, total, average, longest_day, longest_minutes):
+    def set_stats(self, minutes_per_day, total, average, longest_day, longest_time, longest_minutes):
         self.graph.set_minutes(minutes_per_day)
-        self.total_lbl.setText(f"Total this week: {int(total)} min")
-        self.avg_lbl.setText(f"Daily average: {average:.1f} min")
+        self.total_lbl.setText(f"Total esta semana: {int(total)} min")
+        self.avg_lbl.setText(f"Promedio diario: {average:.1f} min")
         if longest_day:
             self.longest_lbl.setText(
-                f"Longest session: {longest_day} – {int(longest_minutes)} min"
+                f"Sesi\u00f3n m\u00e1s larga: {longest_day} {longest_time} – {int(longest_minutes)} min"
             )
         else:
-            self.longest_lbl.setText("Longest session: --")
+            self.longest_lbl.setText("Sesi\u00f3n m\u00e1s larga: --")


### PR DESCRIPTION
## Summary
- translate StatsOverlay strings to Spanish and update title dynamically
- translate session completion view to Spanish
- localize weekly stats labels and display longest session day/time
- show Spanish day abbreviations in bar graph
- store longest session time in data store

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843ffef12f8832b9f02539c372722cb