### PR TITLE
Add guards for painting with zero-size widgets

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -50,6 +50,8 @@ class BreathCircle(QWidget):
     color = Property(QColor, getColor, setColor)
 
     def paintEvent(self, event):
+        if self.width() <= 0 or self.height() <= 0:
+            return
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
         center = self.rect().center()

--- a/calmio/monthly_stats.py
+++ b/calmio/monthly_stats.py
@@ -20,7 +20,7 @@ class MonthlyLineGraph(QWidget):
         self.update()
 
     def paintEvent(self, event):
-        if not self.minutes:
+        if not self.minutes or self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
@@ -89,6 +89,8 @@ class DonutProgress(QWidget):
         self.update()
 
     def paintEvent(self, event):
+        if self.width() <= 0 or self.height() <= 0:
+            return
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
         stroke = 10

--- a/calmio/progress_circle.py
+++ b/calmio/progress_circle.py
@@ -16,6 +16,8 @@ class ProgressCircle(QWidget):
         self.update()
 
     def paintEvent(self, event):
+        if self.width() <= 0 or self.height() <= 0:
+            return
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
         rect = self.rect().adjusted(20, 20, -20, -20)

--- a/calmio/session_details.py
+++ b/calmio/session_details.py
@@ -68,7 +68,7 @@ class BreathGraph(QWidget):
         return path
 
     def paintEvent(self, event):
-        if not self.values:
+        if not self.values or self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)

--- a/calmio/weekly_stats.py
+++ b/calmio/weekly_stats.py
@@ -17,6 +17,8 @@ class WeeklyBarGraph(QWidget):
         self.update()
 
     def paintEvent(self, event):
+        if self.width() <= 0 or self.height() <= 0:
+            return
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
 


### PR DESCRIPTION
## Summary
- avoid QPainter errors by skipping paint logic if widgets are too small

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684408c36118832bb77c9e30f7dfe1e9