### PR TITLE
Add welcome prompt and motivational messages

### DIFF
--- a/calmio/motivational_messages.json
+++ b/calmio/motivational_messages.json
@@ -1,0 +1,7 @@
+{
+  "messages": [
+    "Respira y siente la calma",
+    "Inhala paz, exhala tensi\u00f3n",
+    "Cada respiro te centra en el presente"
+  ]
+}


### PR DESCRIPTION
## Summary
- add sample `motivational_messages.json`
- show a bouncing start prompt below the circle
- display motivational messages read from JSON after several breaths

## Testing
- `python -m py_compile calmio/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68440a9f81ac832b870ea9c8b7d806e2