### PR TITLE
Improve message schedule and add motivational messages

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -156,7 +156,7 @@ class MainWindow(QMainWindow):
         self.position_buttons()
 
         self.load_messages()
-        self.message_schedule = set(range(3, 100, 6))
+        self.build_message_schedule()
         self.message_index = 0
         self.msg_opacity = QGraphicsOpacityEffect(self.message_label)
         self.message_label.setGraphicsEffect(self.msg_opacity)
@@ -384,6 +384,18 @@ class MainWindow(QMainWindow):
                 self.motivational_messages = data.get("messages", [])
         except Exception:
             self.motivational_messages = []
+
+    def build_message_schedule(self, max_count: int = 150):
+        """Generate an increasing interval schedule for motivational messages."""
+        schedule = []
+        interval = 3
+        total = 0
+        while total < max_count:
+            for _ in range(3):
+                total += interval
+                schedule.append(total)
+            interval += 1
+        self.message_schedule = set(schedule)
 
     def start_prompt_animation(self):
         self.message_label.setText("Toca para comenzar")

--- a/calmio/motivational_messages.json
+++ b/calmio/motivational_messages.json
@@ -2,6 +2,11 @@
   "messages": [
     "Respira y siente la calma",
     "Inhala paz, exhala tensi\u00f3n",
-    "Cada respiro te centra en el presente"
+    "Cada respiro te centra en el presente",
+    "Permite que cada aliento te llene de serenidad",
+    "Est\u00e1s haciendo un gran trabajo",
+    "Suelta las distracciones y vuelve a tu respiraci\u00f3n",
+    "Encuentra quietud en este momento",
+    "Tu mente se aclara con cada inhalaci\u00f3n"
   ]
 }


### PR DESCRIPTION
## Summary
- generate an increasing interval schedule for motivational messages
- use the new schedule during startup
- extend the list of motivational messages

## Testing
- `python -m py_compile calmio/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68440c4528d0832b949d4af478693dde