### PR TITLE
Enhance message animations with slower fade and blur

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import (
     QPropertyAnimation,
     QEasingCurve,
     QSequentialAnimationGroup,
+    QParallelAnimationGroup,
     QVariantAnimation,
 )
 from datetime import datetime
@@ -21,6 +22,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QStackedWidget,
     QGraphicsOpacityEffect,
+    QGraphicsBlurEffect,
 )
 
 from .breath_circle import BreathCircle
@@ -170,8 +172,11 @@ class MainWindow(QMainWindow):
         self.load_messages()
         self.build_message_schedule()
         self.message_index = 0
-        self.msg_opacity = QGraphicsOpacityEffect(self.message_label)
-        self.message_label.setGraphicsEffect(self.msg_opacity)
+        self.msg_opacity = QGraphicsOpacityEffect(self.message_container)
+        self.message_container.setGraphicsEffect(self.msg_opacity)
+        self.msg_blur = QGraphicsBlurEffect(self.message_label)
+        self.msg_blur.setBlurRadius(0)
+        self.message_label.setGraphicsEffect(self.msg_blur)
         self.start_prompt_animation()
 
     def update_count(self, count):
@@ -413,9 +418,10 @@ class MainWindow(QMainWindow):
         self.message_label.setText("Toca para comenzar")
         self.message_label.show()
         self.message_container.show()
+        self.msg_blur.setBlurRadius(0)
         self.msg_opacity.setOpacity(0.2)
         self.fade_anim = QPropertyAnimation(self.msg_opacity, b"opacity", self)
-        self.fade_anim.setDuration(1500)
+        self.fade_anim.setDuration(3000)
         self.fade_anim.setStartValue(0.2)
         self.fade_anim.setKeyValueAt(0.5, 1)
         self.fade_anim.setEndValue(0.2)
@@ -423,7 +429,7 @@ class MainWindow(QMainWindow):
         self.fade_anim.start()
 
         self.bounce_anim = QVariantAnimation(self)
-        self.bounce_anim.setDuration(1500)
+        self.bounce_anim.setDuration(3000)
         self.bounce_anim.setStartValue(14)
         self.bounce_anim.setKeyValueAt(0.5, 18)
         self.bounce_anim.setEndValue(14)
@@ -443,7 +449,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "bounce_anim"):
             self.bounce_anim.stop()
         hide = QPropertyAnimation(self.msg_opacity, b"opacity", self)
-        hide.setDuration(500)
+        hide.setDuration(1000)
         hide.setStartValue(self.msg_opacity.opacity())
         hide.setEndValue(0)
         hide.finished.connect(self.message_label.hide)
@@ -454,18 +460,26 @@ class MainWindow(QMainWindow):
         self.msg_opacity.setOpacity(0)
         self.message_label.setText(text)
         self.message_label.show()
+        self.msg_blur.setBlurRadius(0)
         fade_in = QPropertyAnimation(self.msg_opacity, b"opacity", self)
-        fade_in.setDuration(600)
+        fade_in.setDuration(1200)
         fade_in.setStartValue(0)
         fade_in.setEndValue(1)
         fade_out = QPropertyAnimation(self.msg_opacity, b"opacity", self)
-        fade_out.setDuration(600)
+        fade_out.setDuration(1200)
         fade_out.setStartValue(1)
         fade_out.setEndValue(0)
         group = QSequentialAnimationGroup(self)
         group.addAnimation(fade_in)
-        group.addPause(1000)
-        group.addAnimation(fade_out)
+        blur_anim = QPropertyAnimation(self.msg_blur, b"blurRadius", self)
+        blur_anim.setDuration(1200)
+        blur_anim.setStartValue(0)
+        blur_anim.setEndValue(5)
+        group.addPause(2000)
+        fade_out_group = QParallelAnimationGroup(self)
+        fade_out_group.addAnimation(fade_out)
+        fade_out_group.addAnimation(blur_anim)
+        group.addAnimation(fade_out_group)
         group.finished.connect(self.message_label.hide)
         group.start()
         self.temp_msg_anim = group


### PR DESCRIPTION
## Summary
- slow down prompt fade animation and bounce
- animate motivational messages with longer fade times
- apply a subtle blur to messages while fading out
- set opacity effect on message container so blur can be applied to the label

## Testing
- `python -m py_compile calmio/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_684496070d30832ba4dfc302d7a75c46