### PR TITLE
Increase fade-out duration

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -443,7 +443,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "bounce_anim"):
             self.bounce_anim.stop()
         hide = QPropertyAnimation(self.msg_opacity, b"opacity", self)
-        hide.setDuration(500)
+        hide.setDuration(4000)
         hide.setStartValue(self.msg_opacity.opacity())
         hide.setEndValue(0)
         hide.finished.connect(self.message_label.hide)
@@ -459,7 +459,7 @@ class MainWindow(QMainWindow):
         fade_in.setStartValue(0)
         fade_in.setEndValue(1)
         fade_out = QPropertyAnimation(self.msg_opacity, b"opacity", self)
-        fade_out.setDuration(600)
+        fade_out.setDuration(4000)
         fade_out.setStartValue(1)
         fade_out.setEndValue(0)
         group = QSequentialAnimationGroup(self)


### PR DESCRIPTION
## Summary
- slow down fade-out effect for messages on the main screen

## Testing
- `python -m py_compile calmio/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_68449b3fcb8c832b85b92964797f2a36