### PR TITLE
Sync counter opacity with breath

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -26,6 +26,7 @@ class BreathCircle(QWidget):
         self.count_changed_callback = None
         self.breath_started_callback = None
         self.breath_finished_callback = None
+        self.exhale_started_callback = None
         self.breath_start_time = 0
         self.inhale_start_time = 0
         self.exhale_start_time = 0
@@ -83,6 +84,8 @@ class BreathCircle(QWidget):
         self.exhale_start_time = time.perf_counter()
         self.phase = 'exhaling'
         duration = self.exhale_time if self.cycle_valid else 2000
+        if self.exhale_started_callback:
+            self.exhale_started_callback(duration)
         self.animate(self._radius, self.min_radius, duration,
                      target_color=self.base_color)
 


### PR DESCRIPTION
## Summary
- add exhale_started_callback to BreathCircle
- start counter fade-in on inhale and fade-out on exhale
- hide counter at session start and when session completes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68449d8bf198832b98c369b008e68cef