### PR TITLE
Add completion animation and badge system

### DIFF
--- a/calmio/badges.py
+++ b/calmio/badges.py
@@ -1,0 +1,6 @@
+# Mapping of internal badge codes to user-facing names
+BADGE_NAMES = {
+    "5_min_total": "5 minutos meditados",
+    "10_breaths": "10 respiraciones en una sesi\u00f3n",
+    "3_day_streak": "3 d\u00edas consecutivos",
+}

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -169,6 +169,7 @@ class MainWindow(QMainWindow):
                 last.get("cycles", []),
             )
         self.stats_overlay.update_streak(self.data_store.get_streak())
+        self.stats_overlay.update_badges(self.data_store.get_badges())
 
         self.position_buttons()
 
@@ -239,7 +240,7 @@ class MainWindow(QMainWindow):
         start_str = self.session_start.strftime("%H:%M:%S") if self.session_start else ""
         duration_seconds = self.session_seconds
         breaths = self.circle.breath_count
-        self.data_store.add_session(
+        new_badges = self.data_store.add_session(
             self.session_start,
             duration_seconds,
             breaths,
@@ -267,8 +268,13 @@ class MainWindow(QMainWindow):
             start_time_str,
             end_time_str,
         )
+        if new_badges:
+            self.session_complete.show_badges(new_badges)
+        else:
+            self.session_complete.show_badges([])
         self.stack.setCurrentWidget(self.session_complete)
         self.stats_overlay.update_streak(self.data_store.get_streak())
+        self.stats_overlay.update_badges(self.data_store.get_badges())
         for btn in (self.options_button, self.stats_button, self.end_button):
             btn.hide()
 

--- a/calmio/session_complete.py
+++ b/calmio/session_complete.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, Signal, QPropertyAnimation
 from PySide6.QtGui import QFont
 from PySide6.QtWidgets import (
     QWidget,
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QGraphicsDropShadowEffect,
+    QGraphicsOpacityEffect,
 )
 
 
@@ -80,6 +81,16 @@ class SessionComplete(QWidget):
 
         layout.addWidget(card)
 
+        self.badge_label = QLabel("")
+        badge_font = QFont("Sans Serif")
+        badge_font.setPointSize(14)
+        badge_font.setWeight(QFont.Bold)
+        self.badge_label.setFont(badge_font)
+        self.badge_label.setAlignment(Qt.AlignCenter)
+        self.badge_label.setStyleSheet("color:#F39C12;")
+        self.badge_label.hide()
+        layout.addWidget(self.badge_label)
+
         self.phrase = QLabel("Lleva esta calma contigo durante el d\u00eda.")
         ph_font = QFont("Sans Serif")
         ph_font.setPointSize(12)
@@ -87,6 +98,14 @@ class SessionComplete(QWidget):
         self.phrase.setAlignment(Qt.AlignCenter)
         self.phrase.setStyleSheet("color:#666;")
         layout.addWidget(self.phrase)
+
+        # ephemeral star animation widgets
+        self._stars = []
+        for _ in range(5):
+            lbl = QLabel("\u2728", self)
+            lbl.setStyleSheet("font-size:24px;color:#F5B041;")
+            lbl.hide()
+            self._stars.append(lbl)
 
         self.done_btn = QPushButton("Listo")
         self.done_btn.setStyleSheet(
@@ -110,4 +129,33 @@ class SessionComplete(QWidget):
         self.exhale_lbl.setText(f"\u2B07\ufe0f Exhalar: {exhale:.2f}s")
         self.start_lbl.setText(f"\u23F0 Inicio: {start}")
         self.end_lbl.setText(f"\u23F0 Fin: {end}")
+
+    def show_badges(self, badges):
+        from .badges import BADGE_NAMES
+        if badges:
+            names = [BADGE_NAMES.get(b, b) for b in badges]
+            self.badge_label.setText("\u2728 " + ", ".join(names))
+            self.badge_label.show()
+        else:
+            self.badge_label.hide()
+        self.play_completion_animation()
+
+    def play_completion_animation(self):
+        import random
+        for star in self._stars:
+            star.hide()
+        for star in self._stars:
+            x = random.randint(0, max(0, self.width() - star.width()))
+            y = random.randint(0, max(0, self.height() // 2))
+            star.move(x, y)
+            effect = QGraphicsOpacityEffect(star)
+            star.setGraphicsEffect(effect)
+            effect.setOpacity(1)
+            star.show()
+            anim = QPropertyAnimation(effect, b"opacity", self)
+            anim.setDuration(1000)
+            anim.setStartValue(1)
+            anim.setEndValue(0)
+            anim.finished.connect(star.hide)
+            anim.start()
 

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -109,6 +109,12 @@ class StatsOverlay(QWidget):
         today_layout.addWidget(streak_card, alignment=Qt.AlignCenter)
         today_layout.addWidget(self.sessions_btn, alignment=Qt.AlignCenter)
         today_layout.addWidget(self.last_session)
+        self.badges_label = QLabel("")
+        badges_font = QFont("Sans Serif")
+        badges_font.setPointSize(12)
+        self.badges_label.setFont(badges_font)
+        self.badges_label.setWordWrap(True)
+        today_layout.addWidget(self.badges_label, alignment=Qt.AlignCenter)
         today_layout.addStretch()
 
         self.week_view = WeeklyStatsView(self)
@@ -155,6 +161,14 @@ class StatsOverlay(QWidget):
 
     def update_minutes(self, seconds):
         self.progress.set_seconds(seconds)
+
+    def update_badges(self, badges):
+        from .badges import BADGE_NAMES
+        if badges:
+            names = [BADGE_NAMES.get(b, b) for b in badges]
+            self.badges_label.setText("Logros: " + ", ".join(names))
+        else:
+            self.badges_label.setText("")
 
     def update_last_session(self, start, duration, breaths, inhale, exhale, cycles=None):
         self._last_session_data = {


### PR DESCRIPTION
## Summary
- implement simple badge achievements
- display earned badges in stats overlay
- show star animation and badge text when session completes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68449f1e4cf8832b92f488d89001d84c