### PR TITLE
Enhance breathing session visuals

### DIFF
--- a/calmio/animated_background.py
+++ b/calmio/animated_background.py
@@ -1,6 +1,14 @@
 import math
 
-from PySide6.QtCore import Qt, QTimer, Property, QSequentialAnimationGroup, QParallelAnimationGroup, QPropertyAnimation, QPointF
+from PySide6.QtCore import (
+    Qt,
+    QTimer,
+    Property,
+    QSequentialAnimationGroup,
+    QParallelAnimationGroup,
+    QPropertyAnimation,
+    QPointF,
+)
 from PySide6.QtGui import QColor, QPainter, QRadialGradient
 from PySide6.QtWidgets import QWidget
 
@@ -16,6 +24,8 @@ class AnimatedBackground(QWidget):
         self.dark_mode = dark_mode
         self._color1 = QColor(255, 0, 0)
         self._color2 = QColor(255, 80, 80)
+
+        self._opacity = 0.0
 
         self._angle = 0.0
         self._offset_timer = QTimer(self)
@@ -43,6 +53,15 @@ class AnimatedBackground(QWidget):
         self.update()
 
     color2 = Property(QColor, get_color2, set_color2)
+
+    def get_opacity(self):
+        return self._opacity
+
+    def set_opacity(self, value):
+        self._opacity = max(0.0, min(1.0, float(value)))
+        self.update()
+
+    opacity = Property(float, get_opacity, set_opacity)
 
     def _chakra_colors(self):
         base = [
@@ -95,8 +114,11 @@ class AnimatedBackground(QWidget):
 
     def paintEvent(self, event):
         painter = QPainter(self)
-        painter.setRenderHint(QPainter.Antialiasing)
         rect = self.rect()
+        painter.fillRect(rect, QColor("white"))
+        if self._opacity <= 0:
+            return
+        painter.setRenderHint(QPainter.Antialiasing)
         radius = max(rect.width(), rect.height()) * 0.75
         center = rect.center()
         offset_center = QPointF(
@@ -106,5 +128,6 @@ class AnimatedBackground(QWidget):
         gradient = QRadialGradient(offset_center, radius)
         gradient.setColorAt(0, self._color1)
         gradient.setColorAt(1, self._color2)
+        painter.setOpacity(self._opacity)
         painter.fillRect(rect, gradient)
 

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -42,6 +42,7 @@ class MainWindow(QMainWindow):
         palette = QApplication.instance().palette()
         dark_mode = palette.color(QPalette.Window).value() < 128
         self.bg = AnimatedBackground(self, dark_mode=dark_mode)
+        self.bg.set_opacity(0.0)
         self.bg.lower()
         self.bg.setGeometry(self.rect())
 
@@ -102,7 +103,8 @@ class MainWindow(QMainWindow):
         max_font = QFont(msg_font)
         max_font.setPointSize(18)
         fm = QFontMetrics(max_font)
-        self.message_container.setFixedHeight(fm.height())
+        # Allow up to three lines of text while keeping layout stable
+        self.message_container.setFixedHeight(fm.height() * 3)
         # Keep container visible so layout doesn't shift when messages appear
         self.message_container.setVisible(True)
         layout.addWidget(self.message_container, alignment=Qt.AlignHCenter)
@@ -234,6 +236,15 @@ class MainWindow(QMainWindow):
         self.text_color_anim.valueChanged.connect(self._update_label_color)
         self.text_color_anim.start()
 
+        if hasattr(self, "bg_anim") and self.bg_anim.state() != QAbstractAnimation.Stopped:
+            self.bg_anim.stop()
+        self.bg_anim = QPropertyAnimation(self.bg, b"opacity", self)
+        self.bg_anim.setDuration(int(self.circle.inhale_time))
+        self.bg_anim.setStartValue(self.bg.opacity)
+        self.bg_anim.setEndValue(1.0)
+        self.bg_anim.setEasingCurve(QEasingCurve.InOutSine)
+        self.bg_anim.start()
+
     def on_exhale_start(self, duration):
         if (
             hasattr(self, "count_anim")
@@ -255,6 +266,15 @@ class MainWindow(QMainWindow):
         self.text_color_anim.setEndValue(self.base_text_color)
         self.text_color_anim.valueChanged.connect(self._update_label_color)
         self.text_color_anim.start()
+
+        if hasattr(self, "bg_anim") and self.bg_anim.state() != QAbstractAnimation.Stopped:
+            self.bg_anim.stop()
+        self.bg_anim = QPropertyAnimation(self.bg, b"opacity", self)
+        self.bg_anim.setDuration(int(duration))
+        self.bg_anim.setStartValue(self.bg.opacity)
+        self.bg_anim.setEndValue(0.0)
+        self.bg_anim.setEasingCurve(QEasingCurve.InOutSine)
+        self.bg_anim.start()
 
     def on_breath_end(self, duration, inhale, exhale):
         self.last_cycle_duration = duration
@@ -307,6 +327,15 @@ class MainWindow(QMainWindow):
         self.stats_overlay.update_badges(self.data_store.get_badges())
         for btn in (self.options_button, self.stats_button, self.end_button):
             btn.hide()
+
+        if hasattr(self, "bg_anim") and self.bg_anim.state() != QAbstractAnimation.Stopped:
+            self.bg_anim.stop()
+        self.bg_anim = QPropertyAnimation(self.bg, b"opacity", self)
+        self.bg_anim.setDuration(1000)
+        self.bg_anim.setStartValue(self.bg.opacity)
+        self.bg_anim.setEndValue(0.0)
+        self.bg_anim.setEasingCurve(QEasingCurve.InOutSine)
+        self.bg_anim.start()
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Space and not event.isAutoRepeat():


### PR DESCRIPTION
## Summary
- keep instructions text visible while allowing multiple lines
- animate background opacity with breathing cycles
- fade out background when session ends

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68451e66c130832bacc4791402737c43