### PR TITLE
Improve dark theme and ripple animation

### DIFF
--- a/calmio/animated_background.py
+++ b/calmio/animated_background.py
@@ -115,7 +115,7 @@ class AnimatedBackground(QWidget):
     def paintEvent(self, event):
         painter = QPainter(self)
         rect = self.rect()
-        painter.fillRect(rect, QColor("white"))
+        painter.fillRect(rect, QColor("black"))
         if self._opacity <= 0:
             return
         painter.setRenderHint(QPainter.Antialiasing)

--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -146,22 +146,27 @@ class BreathCircle(QWidget):
         if self.ripple_anim:
             self.ripple_anim.stop()
         self.setRippleOpacity(0.6)
-        group = QParallelAnimationGroup(self)
-        r_anim = QPropertyAnimation(self, b"ripple_radius")
-        r_anim.setStartValue(self._radius)
-        r_anim.setEndValue(self._radius * 1.6)
-        r_anim.setDuration(600)
-        r_anim.setEasingCurve(QEasingCurve.OutQuad)
-        o_anim = QPropertyAnimation(self, b"ripple_opacity")
-        o_anim.setStartValue(0.6)
-        o_anim.setEndValue(0.0)
-        o_anim.setDuration(600)
-        o_anim.setEasingCurve(QEasingCurve.OutQuad)
-        group.addAnimation(r_anim)
-        group.addAnimation(o_anim)
-        group.finished.connect(lambda: self.setRippleOpacity(0.0))
-        self.ripple_anim = group
-        group.start()
+        seq = QSequentialAnimationGroup(self)
+        durations = [1500, 1700, 1400]
+        for dur in durations:
+            group = QParallelAnimationGroup(self)
+            r_anim = QPropertyAnimation(self, b"ripple_radius")
+            r_anim.setStartValue(self._radius)
+            r_anim.setEndValue(self._radius * 1.6)
+            r_anim.setDuration(dur)
+            r_anim.setEasingCurve(QEasingCurve.OutQuad)
+            o_anim = QPropertyAnimation(self, b"ripple_opacity")
+            o_anim.setStartValue(0.6)
+            o_anim.setEndValue(0.0)
+            o_anim.setDuration(dur)
+            o_anim.setEasingCurve(QEasingCurve.OutQuad)
+            group.addAnimation(r_anim)
+            group.addAnimation(o_anim)
+            seq.addAnimation(group)
+            seq.addPause(300)
+        seq.finished.connect(lambda: self.setRippleOpacity(0.0))
+        self.ripple_anim = seq
+        seq.start()
 
     def animation_finished(self):
         if self.phase == 'exhaling':

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -38,6 +38,7 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("Calmio")
         self.resize(360, 640)
+        self.setStyleSheet("background-color: black;")
 
         palette = QApplication.instance().palette()
         dark_mode = palette.color(QPalette.Window).value() < 128
@@ -89,9 +90,10 @@ class MainWindow(QMainWindow):
 
         msg_font = QFont("Sans Serif")
         msg_font.setPointSize(14)
-        self.message_label = QLabel("Toca para comenzar")
+        self.message_label = QLabel("Toca para empezar")
         self.message_label.setAlignment(Qt.AlignCenter)
         self.message_label.setFont(msg_font)
+        self.message_label.setStyleSheet("color:white;")
         self.message_label.setWordWrap(True)
         self.message_label.setVisible(False)
         self.message_container = QWidget()
@@ -511,7 +513,7 @@ class MainWindow(QMainWindow):
         self.message_schedule = set(schedule)
 
     def start_prompt_animation(self):
-        self.message_label.setText("Toca para comenzar")
+        self.message_label.setText("Toca para empezar")
         self.message_label.show()
         self.message_container.show()
         self.msg_opacity.setOpacity(0.2)


### PR DESCRIPTION
## Summary
- make the app background black
- adjust the start prompt text and color
- slow down the ripple animation with multiple mysterious waves

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684521bd3384832bb8c6794e4d6039ee