### PR TITLE
Improve start prompt visibility and wave animation

### DIFF
--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -8,6 +8,7 @@ from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .main_window import MainWindow
 from .animated_background import AnimatedBackground
+from .wave_background import WaveBackground
 
 __all__ = [
     "BreathCircle",
@@ -18,4 +19,5 @@ __all__ = [
     "SessionDetailsView",
     "MainWindow",
     "AnimatedBackground",
+    "WaveBackground",
 ]

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -31,6 +31,7 @@ from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .data_store import DataStore
 from .animated_background import AnimatedBackground
+from .wave_background import WaveBackground
 
 
 class MainWindow(QMainWindow):
@@ -41,11 +42,16 @@ class MainWindow(QMainWindow):
         self.setStyleSheet("background-color: black;")
 
         palette = QApplication.instance().palette()
-        dark_mode = palette.color(QPalette.Window).value() < 128
-        self.bg = AnimatedBackground(self, dark_mode=dark_mode)
+        self.dark_mode = palette.color(QPalette.Window).value() < 128
+        self.bg = AnimatedBackground(self, dark_mode=self.dark_mode)
         self.bg.set_opacity(0.0)
         self.bg.lower()
         self.bg.setGeometry(self.rect())
+
+        if not self.dark_mode:
+            self.wave_bg = WaveBackground(self)
+            self.wave_bg.lower()
+            self.wave_bg.setGeometry(self.rect())
 
         self.data_store = DataStore()
 
@@ -93,7 +99,8 @@ class MainWindow(QMainWindow):
         self.message_label = QLabel("Toca para empezar")
         self.message_label.setAlignment(Qt.AlignCenter)
         self.message_label.setFont(msg_font)
-        self.message_label.setStyleSheet("color:white;")
+        text_color = "white" if self.dark_mode else "#000000"
+        self.message_label.setStyleSheet(f"color:{text_color};")
         self.message_label.setWordWrap(True)
         self.message_label.setVisible(False)
         self.message_container = QWidget()
@@ -370,6 +377,8 @@ class MainWindow(QMainWindow):
         self.position_buttons()
         if hasattr(self, "bg"):
             self.bg.setGeometry(self.rect())
+        if hasattr(self, "wave_bg"):
+            self.wave_bg.setGeometry(self.rect())
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.MouseButtonPress:

--- a/calmio/wave_background.py
+++ b/calmio/wave_background.py
@@ -1,0 +1,51 @@
+import math
+import time
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtGui import QColor, QPainter, QPainterPath
+from PySide6.QtWidgets import QWidget
+
+
+class WaveBackground(QWidget):
+    """Decorative animated waves for the light theme."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self.setAutoFillBackground(False)
+
+        self.layers = [
+            {"amplitude": 20, "wavelength": 240, "speed": 0.002, "phase": 0.0, "color": QColor(77, 159, 255, 80)},
+            {"amplitude": 25, "wavelength": 300, "speed": 0.0014, "phase": 1.0, "color": QColor(77, 159, 255, 60)},
+            {"amplitude": 30, "wavelength": 360, "speed": 0.0010, "phase": 2.0, "color": QColor(77, 159, 255, 40)},
+        ]
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self._update_phases)
+        self.timer.start(50)
+
+    def _update_phases(self):
+        for layer in self.layers:
+            layer["phase"] += layer["speed"]
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        w = self.width()
+        h = self.height()
+
+        for layer in self.layers:
+            path = QPainterPath()
+            base_y = h * 0.65
+            path.moveTo(0, h)
+            for x in range(0, w + 1, 2):
+                y = base_y + math.sin(x / layer["wavelength"] + layer["phase"]) * layer["amplitude"]
+                path.lineTo(x, y)
+            path.lineTo(w, h)
+            path.closeSubpath()
+
+            painter.setPen(Qt.NoPen)
+            painter.setBrush(layer["color"])
+            painter.drawPath(path)
+
+


### PR DESCRIPTION
## Summary
- adjust start prompt text color depending on theme
- introduce a WaveBackground widget with slower, layered waves for light mode
- add WaveBackground to main window when running in light mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684523b36304832b887c9ca7e44e2110