### PR TITLE
Improve ripple animation and slower start prompt

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -525,11 +525,11 @@ class MainWindow(QMainWindow):
         self.fade_anim.start()
 
         self.bounce_anim = QVariantAnimation(self)
-        self.bounce_anim.setDuration(1500)
+        self.bounce_anim.setDuration(3000)
         self.bounce_anim.setStartValue(14)
         self.bounce_anim.setKeyValueAt(0.5, 18)
         self.bounce_anim.setEndValue(14)
-        self.bounce_anim.setEasingCurve(QEasingCurve.OutBounce)
+        self.bounce_anim.setEasingCurve(QEasingCurve.InOutSine)
         self.bounce_anim.setLoopCount(-1)
         self.bounce_anim.valueChanged.connect(self._update_message_font)
         self.bounce_anim.start()


### PR DESCRIPTION
## Summary
- create `Ripple` helper for watercolor-style ripples
- animate multiple expanding rings with organic timing
- slow down the "press to start" bounce animation

## Testing
- `python -m py_compile calmio/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684526d44b2c832ba1fce88169d73824