### PR TITLE
Add expanding wave overlay animation

### DIFF
--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -8,6 +8,7 @@ from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .main_window import MainWindow
 from .animated_background import AnimatedBackground
+from .wave_overlay import WaveOverlay
 
 __all__ = [
     "BreathCircle",
@@ -18,4 +19,5 @@ __all__ = [
     "SessionDetailsView",
     "MainWindow",
     "AnimatedBackground",
+    "WaveOverlay",
 ]

--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -64,6 +64,7 @@ class BreathCircle(QWidget):
         self.breath_started_callback = None
         self.breath_finished_callback = None
         self.exhale_started_callback = None
+        self.ripple_spawned_callback = None
         self.breath_start_time = 0
         self.inhale_start_time = 0
         self.exhale_start_time = 0
@@ -237,6 +238,9 @@ class BreathCircle(QWidget):
 
         self.ripple_anim = seq
         seq.start()
+        if self.ripple_spawned_callback:
+            center = self.mapTo(self.window(), self.rect().center())
+            self.ripple_spawned_callback(center, self._color)
 
     def animation_finished(self):
         if self.phase == 'exhaling':

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -31,6 +31,7 @@ from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .data_store import DataStore
 from .animated_background import AnimatedBackground
+from .wave_overlay import WaveOverlay
 
 
 class MainWindow(QMainWindow):
@@ -45,6 +46,9 @@ class MainWindow(QMainWindow):
         self.bg.set_opacity(0.0)
         self.bg.lower()
         self.bg.setGeometry(self.rect())
+        self.wave_overlay = WaveOverlay(self)
+        self.wave_overlay.setGeometry(self.rect())
+        self.wave_overlay.lower()
 
         self.data_store = DataStore()
 
@@ -66,6 +70,7 @@ class MainWindow(QMainWindow):
         self.circle.breath_started_callback = self.on_breath_start
         self.circle.breath_finished_callback = self.on_breath_end
         self.circle.exhale_started_callback = self.on_exhale_start
+        self.circle.ripple_spawned_callback = self.start_waves
 
         font = QFont("Sans Serif")
         font.setPointSize(32)
@@ -123,6 +128,7 @@ class MainWindow(QMainWindow):
         self.stack = QStackedWidget()
         self.stack.addWidget(self.main_view)
         self.stack.addWidget(self.session_complete)
+        self.wave_overlay.stackUnder(self.stack)
 
         self.setCentralWidget(self.stack)
         self.setFocusPolicy(Qt.StrongFocus)
@@ -204,6 +210,10 @@ class MainWindow(QMainWindow):
             self.meditation_seconds += 1
             self.session_seconds += 1
             self.stats_overlay.update_minutes(self.meditation_seconds)
+
+    def start_waves(self, center, color):
+        if hasattr(self, "wave_overlay"):
+            self.wave_overlay.start_waves(center, color)
 
     def on_breath_start(self):
         if not self.session_active:
@@ -369,6 +379,8 @@ class MainWindow(QMainWindow):
         self.position_buttons()
         if hasattr(self, "bg"):
             self.bg.setGeometry(self.rect())
+        if hasattr(self, "wave_overlay"):
+            self.wave_overlay.setGeometry(self.rect())
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.MouseButtonPress:

--- a/calmio/wave_overlay.py
+++ b/calmio/wave_overlay.py
@@ -1,0 +1,112 @@
+from PySide6.QtCore import (
+    Qt,
+    Property,
+    QPropertyAnimation,
+    QParallelAnimationGroup,
+    QSequentialAnimationGroup,
+    QEasingCurve,
+    QPoint,
+    QObject,
+)
+from PySide6.QtGui import QPainter, QColor, QPen
+from PySide6.QtWidgets import QWidget
+
+
+class _Wave(QObject):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self._radius = 0.0
+        self._opacity = 0.0
+
+    def getRadius(self):
+        return self._radius
+
+    def setRadius(self, value):
+        self._radius = value
+        self.parent().update()
+
+    radius = Property(float, getRadius, setRadius)
+
+    def getOpacity(self):
+        return self._opacity
+
+    def setOpacity(self, value):
+        self._opacity = value
+        self.parent().update()
+
+    opacity = Property(float, getOpacity, setOpacity)
+
+
+class WaveOverlay(QWidget):
+    """Transparent widget that draws expanding waves from a center point."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WA_NoSystemBackground, True)
+        self.setAttribute(Qt.WA_TranslucentBackground, True)
+        self._waves = []
+        self._center = QPoint(0, 0)
+        self._color = QColor(0, 0, 0)
+        self.hide()
+
+    def start_waves(self, center: QPoint, color: QColor):
+        self._center = center
+        self._color = QColor(color)
+        diag = int((self.width() ** 2 + self.height() ** 2) ** 0.5)
+        configs = [
+            {"delay": 0, "duration": 2000, "opacity": 0.25},
+            {"delay": 400, "duration": 3500, "opacity": 0.2},
+            {"delay": 800, "duration": 5000, "opacity": 0.15},
+        ]
+        for cfg in configs:
+            wave = _Wave(self)
+            wave.setRadius(0)
+            wave.setOpacity(cfg["opacity"])
+            self._waves.append(wave)
+            group = QParallelAnimationGroup(self)
+            r = QPropertyAnimation(wave, b"radius")
+            r.setStartValue(0)
+            r.setEndValue(diag)
+            r.setDuration(cfg["duration"])
+            r.setEasingCurve(QEasingCurve.OutSine)
+            o = QPropertyAnimation(wave, b"opacity")
+            o.setStartValue(cfg["opacity"])
+            o.setEndValue(0.0)
+            o.setDuration(cfg["duration"])
+            o.setEasingCurve(QEasingCurve.OutSine)
+            group.addAnimation(r)
+            group.addAnimation(o)
+            group.finished.connect(lambda w=wave: self._remove_wave(w))
+            if cfg["delay"] > 0:
+                seq = QSequentialAnimationGroup(self)
+                seq.addPause(cfg["delay"])
+                seq.addAnimation(group)
+                seq.start()
+            else:
+                group.start()
+        self.show()
+
+    def _remove_wave(self, wave):
+        if wave in self._waves:
+            self._waves.remove(wave)
+        if not self._waves:
+            self.hide()
+
+    def paintEvent(self, event):
+        if not self._waves:
+            return
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        for wave in list(self._waves):
+            if wave._opacity <= 0:
+                continue
+            pen_color = QColor(self._color)
+            pen_color.setAlphaF(min(1.0, max(0.0, wave._opacity)))
+            pen = QPen(pen_color)
+            pen.setWidth(2)
+            painter.setPen(pen)
+            painter.setBrush(Qt.NoBrush)
+            painter.drawEllipse(self._center, int(wave._radius), int(wave._radius))
+
+


### PR DESCRIPTION
## Summary
- create `WaveOverlay` widget to display concentric expanding waves
- trigger overlay from `BreathCircle` via callback
- integrate overlay in `MainWindow`

## Testing
- `pip install -q -r requirements.txt --break-system-packages`
- `python -m py_compile main.py calmio/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68452844f244832b9c4d2bbf39f099dd