### PR TITLE
Simplify ripple animation

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -199,45 +199,20 @@ class BreathCircle(QWidget):
         r_anim = QPropertyAnimation(self, b"ripple_radius")
         r_anim.setStartValue(self._radius)
         r_anim.setEndValue(self._radius * 1.5)
-        r_anim.setDuration(1200)
+        r_anim.setDuration(2000)
         r_anim.setEasingCurve(QEasingCurve.InOutSine)
         o_anim = QPropertyAnimation(self, b"ripple_opacity")
         o_anim.setStartValue(0.4)
         o_anim.setEndValue(0.0)
-        o_anim.setDuration(1200)
+        o_anim.setDuration(2000)
         o_anim.setEasingCurve(QEasingCurve.InOutSine)
         base_group.addAnimation(r_anim)
         base_group.addAnimation(o_anim)
         base_group.finished.connect(lambda: self.setRippleOpacity(0.0))
 
-        # additional watercolor style ripples
-        seq = QSequentialAnimationGroup(self)
-        seq.addAnimation(base_group)
-
-        for i in range(2):
-            delay = 200 * (i + 1)
-            ripple = Ripple(self, self._radius)
-            self.ripples.append(ripple)
-            group = QParallelAnimationGroup(self)
-            dur = 1200 + i * 300 + random.randint(-150, 150)
-            r = QPropertyAnimation(ripple, b"radius")
-            r.setStartValue(self._radius)
-            r.setEndValue(self._radius * (1.6 + 0.4 * i))
-            r.setDuration(dur)
-            r.setEasingCurve(QEasingCurve.InOutSine)
-            o = QPropertyAnimation(ripple, b"opacity")
-            o.setStartValue(0.3)
-            o.setEndValue(0.0)
-            o.setDuration(dur)
-            o.setEasingCurve(QEasingCurve.InOutSine)
-            group.addAnimation(r)
-            group.addAnimation(o)
-            group.finished.connect(lambda r=ripple: self.ripples.remove(r) if r in self.ripples else None)
-            seq.addPause(delay)
-            seq.addAnimation(group)
-
-        self.ripple_anim = seq
-        seq.start()
+        # Play only the base ripple animation
+        self.ripple_anim = base_group
+        base_group.start()
         if self.ripple_spawned_callback:
             center = self.mapTo(self.window(), self.rect().center())
             self.ripple_spawned_callback(center, self._color)

--- a/calmio/wave_overlay.py
+++ b/calmio/wave_overlay.py
@@ -52,23 +52,18 @@ class WaveOverlay(QWidget):
         self._center = center
         self._color = QColor(color)
         diag = (self.width() ** 2 + self.height() ** 2) ** 0.5 * 1.5
-        configs = [
-            {"duration": 1500, "opacity": 0.25},
-            {"duration": 3000, "opacity": 0.2},
-            {"duration": 4500, "opacity": 0.15},
-        ]
-        for cfg in configs:
-            wave = _Wave(self)
-            wave.setRadius(0)
-            wave.setOpacity(cfg["opacity"])
-            self._waves.append(wave)
-            anim = QPropertyAnimation(wave, b"radius", self)
-            anim.setStartValue(0)
-            anim.setEndValue(diag)
-            anim.setDuration(cfg["duration"])
-            anim.setEasingCurve(QEasingCurve.OutSine)
-            anim.finished.connect(lambda w=wave: self._remove_wave(w))
-            anim.start()
+        # Create a single, slower wave instead of multiple ones
+        wave = _Wave(self)
+        wave.setRadius(0)
+        wave.setOpacity(0.2)
+        self._waves.append(wave)
+        anim = QPropertyAnimation(wave, b"radius", self)
+        anim.setStartValue(0)
+        anim.setEndValue(diag)
+        anim.setDuration(6000)
+        anim.setEasingCurve(QEasingCurve.OutSine)
+        anim.finished.connect(lambda w=wave: self._remove_wave(w))
+        anim.start()
         self.show()
 
     def _remove_wave(self, wave):


### PR DESCRIPTION
## Summary
- slow down the wave overlay and reduce to a single wave
- simplify BreathCircle ripple to one slow animation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452d0c1d5c832b9faabac430a90c07