### PR TITLE
Add today and session achievement views

### DIFF
--- a/calmio/badges_view.py
+++ b/calmio/badges_view.py
@@ -1,0 +1,81 @@
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QHBoxLayout,
+    QPushButton,
+    QScrollArea,
+    QFrame,
+    QGraphicsDropShadowEffect,
+)
+
+
+class BadgesView(QWidget):
+    """Simple list view for badges."""
+
+    back_requested = Signal()
+
+    def __init__(self, parent=None, title="Logros"):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setStyleSheet("background-color:#FAFAFA;color:#444;")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(20)
+
+        header = QHBoxLayout()
+        self.back_btn = QPushButton("\u2190")
+        self.back_btn.setStyleSheet(
+            "QPushButton{background:none;border:none;font-size:18px;}"
+        )
+        self.back_btn.clicked.connect(self.back_requested.emit)
+        header.addWidget(self.back_btn, alignment=Qt.AlignLeft)
+
+        self.title_lbl = QLabel(title)
+        t_font = QFont("Sans Serif")
+        t_font.setPointSize(20)
+        t_font.setWeight(QFont.Medium)
+        self.title_lbl.setFont(t_font)
+        self.title_lbl.setAlignment(Qt.AlignCenter)
+        header.addWidget(self.title_lbl, alignment=Qt.AlignCenter)
+        header.addStretch()
+        layout.addLayout(header)
+
+        self.scroll = QScrollArea()
+        self.scroll.setWidgetResizable(True)
+        layout.addWidget(self.scroll)
+
+        self.container = QWidget()
+        self.list_layout = QVBoxLayout(self.container)
+        self.list_layout.setSpacing(10)
+        self.list_layout.setContentsMargins(0, 0, 0, 0)
+        self.list_layout.addStretch()
+        self.scroll.setWidget(self.container)
+
+    def set_badges(self, badges):
+        from .badges import BADGE_NAMES
+
+        for i in reversed(range(self.list_layout.count() - 1)):
+            item = self.list_layout.takeAt(i)
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()
+
+        for idx, b in enumerate(badges):
+            card = QFrame()
+            card.setStyleSheet("background:#E0F0FF;border-radius:15px;padding:6px;")
+            eff = QGraphicsDropShadowEffect(self)
+            eff.setBlurRadius(8)
+            eff.setOffset(0, 2)
+            card.setGraphicsEffect(eff)
+            row = QHBoxLayout(card)
+            row.setContentsMargins(6, 2, 6, 2)
+            label = QLabel(BADGE_NAMES.get(b, b))
+            label.setAlignment(Qt.AlignLeft)
+            label.setWordWrap(True)
+            row.addWidget(label)
+            self.list_layout.insertWidget(idx, card)
+

--- a/calmio/session_details.py
+++ b/calmio/session_details.py
@@ -118,6 +118,7 @@ class SessionDetailsView(QWidget):
     """View showing detailed breathing data for a session."""
 
     back_requested = Signal()
+    badges_requested = Signal(list)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -209,6 +210,15 @@ class SessionDetailsView(QWidget):
         self.graph = BreathGraph(self)
         layout.addWidget(self.graph)
 
+        self.badges_btn = QPushButton("Logros de sesi\u00f3n")
+        self.badges_btn.setStyleSheet(
+            "QPushButton{"
+            "background-color:#CCE4FF;border:none;border-radius:20px;"
+            "padding:12px 24px;font-size:14px;}"
+        )
+        self.badges_btn.clicked.connect(self._emit_badges)
+        layout.addWidget(self.badges_btn, alignment=Qt.AlignCenter)
+
         self.phrase = QLabel("Tu respiraci\u00F3n se profundiz\u00F3 progresivamente.")
         ph_font = QFont("Sans Serif")
         ph_font.setPointSize(12)
@@ -250,3 +260,12 @@ class SessionDetailsView(QWidget):
         self.tag_lbl.setVisible(is_last)
 
         self.graph.set_cycles(cycles)
+        
+        self.session_badges = session.get("badges", [])
+        self.badges_btn.setVisible(bool(self.session_badges))
+
+    def _emit_badges(self, evt=None):
+        if self.session_badges:
+            self.badges_requested.emit(self.session_badges)
+
+

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -20,6 +20,7 @@ from .monthly_stats import MonthlyStatsView
 class StatsOverlay(QWidget):
     view_sessions = Signal()
     session_requested = Signal(dict)
+    view_badges_today = Signal()
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setAttribute(Qt.WA_StyledBackground, True)
@@ -77,6 +78,15 @@ class StatsOverlay(QWidget):
 
         self.sessions_btn.clicked.connect(self.view_sessions.emit)
 
+        self.badges_btn = QPushButton("Logros alcanzados hoy")
+        self.badges_btn.setStyleSheet(
+            "QPushButton{"
+            "background-color:#CCE4FF;border:none;border-radius:20px;"
+            "padding:12px 24px;font-size:14px;}"
+        )
+        self.badges_btn.clicked.connect(self.view_badges_today.emit)
+        self.badges_btn.hide()
+
         self.last_session = QFrame()
         self.last_session.setStyleSheet(
             "background:#E0F0FF;border-radius:15px;padding:6px;"
@@ -108,13 +118,8 @@ class StatsOverlay(QWidget):
         today_layout.addWidget(self.progress, alignment=Qt.AlignCenter)
         today_layout.addWidget(streak_card, alignment=Qt.AlignCenter)
         today_layout.addWidget(self.sessions_btn, alignment=Qt.AlignCenter)
+        today_layout.addWidget(self.badges_btn, alignment=Qt.AlignCenter)
         today_layout.addWidget(self.last_session)
-        self.badges_label = QLabel("")
-        badges_font = QFont("Sans Serif")
-        badges_font.setPointSize(12)
-        self.badges_label.setFont(badges_font)
-        self.badges_label.setWordWrap(True)
-        today_layout.addWidget(self.badges_label, alignment=Qt.AlignCenter)
         today_layout.addStretch()
 
         self.week_view = WeeklyStatsView(self)
@@ -163,12 +168,12 @@ class StatsOverlay(QWidget):
         self.progress.set_seconds(seconds)
 
     def update_badges(self, badges):
-        from .badges import BADGE_NAMES
         if badges:
-            names = [BADGE_NAMES.get(b, b) for b in badges]
-            self.badges_label.setText("Logros: " + ", ".join(names))
+            self.badges_btn.setText(f"Logros alcanzados hoy ({len(badges)})")
+            self.badges_btn.show()
         else:
-            self.badges_label.setText("")
+            self.badges_btn.setText("Logros alcanzados hoy")
+            self.badges_btn.hide()
 
     def update_last_session(self, start, duration, breaths, inhale, exhale, cycles=None):
         self._last_session_data = {


### PR DESCRIPTION
## Summary
- track daily badges in `DataStore`
- provide `BadgesView` for listing achievements
- show a button in `StatsOverlay` to view today's achievements
- add achievements button to session details
- handle showing/hiding new view from `MainWindow`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68453593b2a8832b85734d114ae40027