### PR TITLE
Add daily badges button and darken menu icon

### DIFF
--- a/calmio/badges.py
+++ b/calmio/badges.py
@@ -1,6 +1,6 @@
 # Mapping of internal badge codes to user-facing names
 BADGE_NAMES = {
-    "5_min_total": "5 minutos meditados",
-    "10_breaths": "10 respiraciones en una sesi\u00f3n",
-    "3_day_streak": "3 d\u00edas consecutivos",
+    "5_min_total": "\u23F1\uFE0F 5 minutos meditados",
+    "10_breaths": "\U0001F32C\uFE0F 10 respiraciones en una sesi\u00f3n",
+    "3_day_streak": "\ud83d\udd25 3 d\u00edas consecutivos",
 }

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -136,7 +136,9 @@ class MainWindow(QMainWindow):
 
         self.menu_button = QPushButton("\u22EF", self)
         self.menu_button.setFixedSize(40, 40)
-        self.menu_button.setStyleSheet("background:none; border:none; font-size:24px;")
+        self.menu_button.setStyleSheet(
+            "background:none; border:none; font-size:24px; color:#000;"
+        )
         self.menu_button.clicked.connect(self.toggle_menu)
 
         QApplication.instance().installEventFilter(self)

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -85,7 +85,6 @@ class StatsOverlay(QWidget):
             "padding:12px 24px;font-size:14px;}"
         )
         self.badges_btn.clicked.connect(self.view_badges_today.emit)
-        self.badges_btn.hide()
 
         self.last_session = QFrame()
         self.last_session.setStyleSheet(
@@ -168,12 +167,9 @@ class StatsOverlay(QWidget):
         self.progress.set_seconds(seconds)
 
     def update_badges(self, badges):
-        if badges:
-            self.badges_btn.setText(f"Logros alcanzados hoy ({len(badges)})")
-            self.badges_btn.show()
-        else:
-            self.badges_btn.setText("Logros alcanzados hoy")
-            self.badges_btn.hide()
+        count = len(badges)
+        self.badges_btn.setText(f"Logros de hoy ({count})")
+        self.badges_btn.setEnabled(bool(badges))
 
     def update_last_session(self, start, duration, breaths, inhale, exhale, cycles=None):
         self._last_session_data = {


### PR DESCRIPTION
## Summary
- make the three-dot menu button black
- always show today's badges button in the stats overlay
- display emoji with badge names

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684538a6aed4832b989224361d64d2d0