### PR TITLE
Support repeated session badges

### DIFF
--- a/calmio/badges_view.py
+++ b/calmio/badges_view.py
@@ -55,6 +55,8 @@ class BadgesView(QWidget):
         self.list_layout.addStretch()
         self.scroll.setWidget(self.container)
 
+    LEVEL_EMOJIS = ["\ud83e\udd49", "\ud83e\udd49", "\ud83e\udd49", "\ud83e\udd48", "\ud83e\udd48", "\ud83e\udd47", "\ud83e\udd47", "\ud83d\udc8e", "\ud83d\udc8e", "\ud83c\udfc6"]
+
     def set_badges(self, badges):
         from .badges import BADGE_NAMES
 
@@ -64,7 +66,13 @@ class BadgesView(QWidget):
             if w is not None:
                 w.deleteLater()
 
-        for idx, b in enumerate(badges):
+        if isinstance(badges, dict):
+            items = badges.items()
+        else:
+            from collections import Counter
+            items = Counter(badges).items()
+
+        for idx, (code, count) in enumerate(items):
             card = QFrame()
             card.setStyleSheet("background:#E0F0FF;border-radius:15px;padding:6px;")
             eff = QGraphicsDropShadowEffect(self)
@@ -73,7 +81,9 @@ class BadgesView(QWidget):
             card.setGraphicsEffect(eff)
             row = QHBoxLayout(card)
             row.setContentsMargins(6, 2, 6, 2)
-            label = QLabel(BADGE_NAMES.get(b, b))
+            level = min(count, len(self.LEVEL_EMOJIS))
+            medal = self.LEVEL_EMOJIS[level - 1]
+            label = QLabel(f"{medal} {BADGE_NAMES.get(code, code)} - Nivel {level}")
             label.setAlignment(Qt.AlignLeft)
             label.setWordWrap(True)
             row.addWidget(label)

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -167,9 +167,12 @@ class StatsOverlay(QWidget):
         self.progress.set_seconds(seconds)
 
     def update_badges(self, badges):
-        count = len(badges)
+        if isinstance(badges, dict):
+            count = sum(badges.values())
+        else:
+            count = len(badges)
         self.badges_btn.setText(f"Logros de hoy ({count})")
-        self.badges_btn.setEnabled(bool(badges))
+        self.badges_btn.setEnabled(count > 0)
 
     def update_last_session(self, start, duration, breaths, inhale, exhale, cycles=None):
         self._last_session_data = {


### PR DESCRIPTION
## Summary
- track daily badge counts instead of unique badges
- show badge levels using medals in `BadgesView`
- update stats overlay to count badge levels

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6845411f27d4832b8f8e631910aab5f5