### PR TITLE
Add developer mode and data reset option

### DIFF
--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -9,6 +9,7 @@ from .session_details import SessionDetailsView
 from .main_window import MainWindow
 from .animated_background import AnimatedBackground
 from .wave_overlay import WaveOverlay
+from .options_dialog import OptionsDialog
 
 __all__ = [
     "BreathCircle",
@@ -20,4 +21,5 @@ __all__ = [
     "MainWindow",
     "AnimatedBackground",
     "WaveOverlay",
+    "OptionsDialog",
 ]

--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -73,6 +73,13 @@ class BreathCircle(QWidget):
         self.ripple_anim = None
         self.ripples = []
         self.setMinimumSize(self.max_radius * 2 + 20, self.max_radius * 2 + 20)
+        self.speed_multiplier = 1.0
+
+    def set_speed_multiplier(self, factor: float):
+        """Set speed multiplier for animations."""
+        if factor <= 0:
+            factor = 1.0
+        self.speed_multiplier = factor
 
     def getRadius(self):
         return self._radius
@@ -152,8 +159,12 @@ class BreathCircle(QWidget):
         if self.breath_started_callback:
             self.breath_started_callback()
         self.cycle_valid = False
-        self.animate(self._radius, self.max_radius, self.inhale_time,
-                     target_color=self.complement_color)
+        self.animate(
+            self._radius,
+            self.max_radius,
+            self.inhale_time,
+            target_color=self.complement_color,
+        )
 
     def start_exhale(self):
         if self.phase != 'inhaling':
@@ -164,8 +175,12 @@ class BreathCircle(QWidget):
         duration = self.exhale_time if self.cycle_valid else 2000
         if self.exhale_started_callback:
             self.exhale_started_callback(duration)
-        self.animate(self._radius, self.min_radius, duration,
-                     target_color=self.base_color)
+        self.animate(
+            self._radius,
+            self.min_radius,
+            duration,
+            target_color=self.base_color,
+        )
 
     def animate(self, start, end, duration, target_color):
         if self.animation:
@@ -175,13 +190,14 @@ class BreathCircle(QWidget):
         radius_anim = QPropertyAnimation(self, b"radius")
         radius_anim.setStartValue(start)
         radius_anim.setEndValue(end)
-        radius_anim.setDuration(int(duration))
+        adj_duration = int(duration / self.speed_multiplier)
+        radius_anim.setDuration(adj_duration)
         radius_anim.setEasingCurve(QEasingCurve.InOutSine)
 
         color_anim = QPropertyAnimation(self, b"color")
         color_anim.setStartValue(self._color)
         color_anim.setEndValue(target_color)
-        color_anim.setDuration(int(duration))
+        color_anim.setDuration(adj_duration)
         color_anim.setEasingCurve(QEasingCurve.InOutSine)
 
         self.animation.addAnimation(radius_anim)
@@ -199,12 +215,12 @@ class BreathCircle(QWidget):
         r_anim = QPropertyAnimation(self, b"ripple_radius")
         r_anim.setStartValue(self._radius)
         r_anim.setEndValue(self._radius * 1.5)
-        r_anim.setDuration(2000)
+        r_anim.setDuration(int(2000 / self.speed_multiplier))
         r_anim.setEasingCurve(QEasingCurve.InOutSine)
         o_anim = QPropertyAnimation(self, b"ripple_opacity")
         o_anim.setStartValue(0.4)
         o_anim.setEndValue(0.0)
-        o_anim.setDuration(2000)
+        o_anim.setDuration(int(2000 / self.speed_multiplier))
         o_anim.setEasingCurve(QEasingCurve.InOutSine)
         base_group.addAnimation(r_anim)
         base_group.addAnimation(o_anim)

--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -52,6 +52,20 @@ class DataStore:
         with self.path.open("w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2)
 
+    def reset(self):
+        """Delete stored data and reinitialize."""
+        if self.path.exists():
+            self.path.unlink()
+        self.data = {
+            "daily_seconds": {},
+            "last_session": {},
+            "streak": 1,
+            "sessions": [],
+            "badges": {},
+            "daily_badges": {},
+        }
+        self.save()
+
     def add_session(self, start_dt, seconds, breaths, inhale, exhale, cycles=None):
         date_key = start_dt.date().isoformat()
         self.data["daily_seconds"][date_key] = (

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -161,6 +161,10 @@ class MainWindow(QMainWindow):
             btn.hide()
 
         self.end_button.clicked.connect(self.end_session)
+        self.options_button.clicked.connect(self.open_options)
+
+        self.click_times = []
+        self.developer_mode = False
 
         self.menu_button.setFocusPolicy(Qt.NoFocus)
 
@@ -435,6 +439,12 @@ class MainWindow(QMainWindow):
             self.stats_button.show()
             self.end_button.show()
 
+    def open_options(self):
+        from .options_dialog import OptionsDialog
+
+        dlg = OptionsDialog(self, self.data_store)
+        dlg.exec()
+
     def toggle_stats(self):
         if self.stats_overlay.isVisible():
             self.stats_overlay.hide()
@@ -483,6 +493,7 @@ class MainWindow(QMainWindow):
             self.today_sessions.hide()
             self.session_details.hide()
             self.badges_view.hide()
+        self._check_dev_click()
         super().mousePressEvent(event)
 
     def on_session_complete_done(self):
@@ -640,3 +651,15 @@ class MainWindow(QMainWindow):
             msg = self.motivational_messages[self.message_index % len(self.motivational_messages)]
             self.message_index += 1
             self.display_motivational_message(msg)
+
+    def _check_dev_click(self):
+        now = time.perf_counter()
+        self.click_times = [t for t in self.click_times if now - t < 2]
+        self.click_times.append(now)
+        if len(self.click_times) >= 5 and not self.developer_mode:
+            self.enable_developer_mode()
+
+    def enable_developer_mode(self):
+        self.developer_mode = True
+        self.circle.set_speed_multiplier(10.0)
+        self.display_motivational_message("Modo desarrollador x10 activado")

--- a/calmio/options_dialog.py
+++ b/calmio/options_dialog.py
@@ -1,0 +1,29 @@
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QPushButton, QMessageBox
+
+
+class OptionsDialog(QDialog):
+    def __init__(self, parent=None, data_store=None):
+        super().__init__(parent)
+        self.setWindowTitle("Opciones")
+        self.data_store = data_store
+        layout = QVBoxLayout(self)
+        self.clear_btn = QPushButton("Borrar todos los datos")
+        self.clear_btn.clicked.connect(self.confirm_clear)
+        layout.addWidget(self.clear_btn)
+        self.setLayout(layout)
+
+    def confirm_clear(self):
+        reply = QMessageBox.question(
+            self,
+            "Confirmar",
+            "¿Estás seguro de borrar todos los datos?",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes and self.data_store is not None:
+            if hasattr(self.data_store, "reset"):
+                self.data_store.reset()
+            else:
+                # Fallback: delete file and reload
+                self.data_store.path.unlink(missing_ok=True)
+                self.data_store.load()
+


### PR DESCRIPTION
## Summary
- implement speed multiplier support for `BreathCircle`
- add developer mode activation on 5 quick clicks
- provide `OptionsDialog` with a button to clear stored data
- expose new dialog and developer mode in `MainWindow`
- allow datastore to reset itself

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845430971e4832bb9a299d4841ca9c3