### PR TITLE
Add developer mode and data reset options

### DIFF
--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -6,6 +6,7 @@ from .stats_overlay import StatsOverlay
 from .session_complete import SessionComplete
 from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
+from .options_overlay import OptionsOverlay
 from .main_window import MainWindow
 from .animated_background import AnimatedBackground
 from .wave_overlay import WaveOverlay
@@ -17,6 +18,7 @@ __all__ = [
     "SessionComplete",
     "TodaySessionsView",
     "SessionDetailsView",
+    "OptionsOverlay",
     "MainWindow",
     "AnimatedBackground",
     "WaveOverlay",

--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -56,6 +56,7 @@ class BreathCircle(QWidget):
         # Third inhale should be around 4.3 seconds (150ms per cycle)
         # Reduce progression speed by half
         self.increment = 75
+        self.speed_multiplier = 1.0
         self.animation = None
         self.phase = 'idle'
         self.breath_count = 0
@@ -152,8 +153,13 @@ class BreathCircle(QWidget):
         if self.breath_started_callback:
             self.breath_started_callback()
         self.cycle_valid = False
-        self.animate(self._radius, self.max_radius, self.inhale_time,
-                     target_color=self.complement_color)
+        dur = self.inhale_time / self.speed_multiplier
+        self.animate(
+            self._radius,
+            self.max_radius,
+            dur,
+            target_color=self.complement_color,
+        )
 
     def start_exhale(self):
         if self.phase != 'inhaling':
@@ -162,6 +168,7 @@ class BreathCircle(QWidget):
         self.exhale_start_time = time.perf_counter()
         self.phase = 'exhaling'
         duration = self.exhale_time if self.cycle_valid else 2000
+        duration /= self.speed_multiplier
         if self.exhale_started_callback:
             self.exhale_started_callback(duration)
         self.animate(self._radius, self.min_radius, duration,
@@ -175,13 +182,13 @@ class BreathCircle(QWidget):
         radius_anim = QPropertyAnimation(self, b"radius")
         radius_anim.setStartValue(start)
         radius_anim.setEndValue(end)
-        radius_anim.setDuration(int(duration))
+        radius_anim.setDuration(int(duration / self.speed_multiplier))
         radius_anim.setEasingCurve(QEasingCurve.InOutSine)
 
         color_anim = QPropertyAnimation(self, b"color")
         color_anim.setStartValue(self._color)
         color_anim.setEndValue(target_color)
-        color_anim.setDuration(int(duration))
+        color_anim.setDuration(int(duration / self.speed_multiplier))
         color_anim.setEasingCurve(QEasingCurve.InOutSine)
 
         self.animation.addAnimation(radius_anim)
@@ -199,12 +206,12 @@ class BreathCircle(QWidget):
         r_anim = QPropertyAnimation(self, b"ripple_radius")
         r_anim.setStartValue(self._radius)
         r_anim.setEndValue(self._radius * 1.5)
-        r_anim.setDuration(2000)
+        r_anim.setDuration(int(2000 / self.speed_multiplier))
         r_anim.setEasingCurve(QEasingCurve.InOutSine)
         o_anim = QPropertyAnimation(self, b"ripple_opacity")
         o_anim.setStartValue(0.4)
         o_anim.setEndValue(0.0)
-        o_anim.setDuration(2000)
+        o_anim.setDuration(int(2000 / self.speed_multiplier))
         o_anim.setEasingCurve(QEasingCurve.InOutSine)
         base_group.addAnimation(r_anim)
         base_group.addAnimation(o_anim)

--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -283,3 +283,20 @@ class DataStore:
             "longest_streak": longest,
             "goal": goal,
         }
+
+    def clear_data(self):
+        """Delete stored data and reset to defaults."""
+        if self.path.exists():
+            try:
+                self.path.unlink()
+            except OSError:
+                pass
+        self.data = {
+            "daily_seconds": {},
+            "last_session": {},
+            "streak": 1,
+            "sessions": [],
+            "badges": {},
+            "daily_badges": {},
+        }
+        self.save()

--- a/calmio/options_overlay.py
+++ b/calmio/options_overlay.py
@@ -1,0 +1,72 @@
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QHBoxLayout,
+    QPushButton,
+    QMessageBox,
+)
+
+
+class OptionsOverlay(QWidget):
+    """Simple configuration overlay with data reset option."""
+
+    back_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setStyleSheet("background-color:#FAFAFA;color:#444;")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(20)
+
+        header = QHBoxLayout()
+        self.back_btn = QPushButton("\u2190")
+        self.back_btn.setStyleSheet(
+            "QPushButton{background:none;border:none;font-size:18px;}"
+        )
+        self.back_btn.clicked.connect(self.back_requested.emit)
+        header.addWidget(self.back_btn, alignment=Qt.AlignLeft)
+
+        title = QLabel("Configuraci\u00f3n")
+        t_font = QFont("Sans Serif")
+        t_font.setPointSize(20)
+        t_font.setWeight(QFont.Medium)
+        title.setFont(t_font)
+        title.setAlignment(Qt.AlignCenter)
+        header.addWidget(title, alignment=Qt.AlignCenter)
+        header.addStretch()
+        layout.addLayout(header)
+
+        self.reset_btn = QPushButton("Borrar todos los datos")
+        self.reset_btn.setStyleSheet(
+            "QPushButton{" "background-color:#CCE4FF;border:none;border-radius:20px;"
+            "padding:12px 24px;font-size:14px;}"
+        )
+        self.reset_btn.clicked.connect(self.confirm_reset)
+        layout.addWidget(self.reset_btn, alignment=Qt.AlignCenter)
+
+        layout.addStretch()
+
+    def confirm_reset(self):
+        reply = QMessageBox.question(
+            self,
+            "Confirmar",
+            "\u00bfEst\u00e1s seguro de borrar todos los datos?",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            store = getattr(self.parent(), "data_store", None)
+            if store:
+                store.clear_data()
+            if hasattr(self.parent(), "stats_overlay"):
+                self.parent().stats_overlay.update_minutes(0)
+                self.parent().stats_overlay.update_streak(0)
+                self.parent().stats_overlay.update_last_session("", 0, 0, 0, 0, [])
+                self.parent().stats_overlay.update_badges({})
+            self.parent().meditation_seconds = 0
+            QMessageBox.information(self, "Listo", "Datos borrados")


### PR DESCRIPTION
## Summary
- add `clear_data` method for deleting stored stats
- create an `OptionsOverlay` with button to wipe app data
- expose the overlay and a bug icon in the menu
- implement developer mode that speeds the app x10

## Testing
- `python -m py_compile main.py calmio/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684544d8edd4832b9f8732d73b8309a5