### PR TITLE
Implement developer overlay and fix badge categorization

### DIFF
--- a/calmio/developer_overlay.py
+++ b/calmio/developer_overlay.py
@@ -1,0 +1,36 @@
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton
+
+
+class DeveloperOverlay(QWidget):
+    """Small menu for developer options."""
+
+    speed_toggled = Signal()
+    next_day_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setStyleSheet(
+            "background-color:#FAFAFA;border-radius:10px;"
+            "border:1px solid #ccc;"
+        )
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(10)
+
+        self.speed_btn = QPushButton("\u26A1")
+        self.day_btn = QPushButton("\u23E9")
+        for btn in (self.speed_btn, self.day_btn):
+            btn.setFixedSize(40, 40)
+            btn.setStyleSheet(
+                "QPushButton{background:white;border:none;font-size:20px;}"
+            )
+            btn.setFocusPolicy(Qt.NoFocus)
+
+        self.speed_btn.clicked.connect(self.speed_toggled.emit)
+        self.day_btn.clicked.connect(self.next_day_requested.emit)
+
+        layout.addWidget(self.speed_btn)
+        layout.addWidget(self.day_btn)

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -1,6 +1,5 @@
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
-from datetime import datetime
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -257,7 +256,7 @@ class StatsOverlay(QWidget):
         store = getattr(self.parent(), "data_store", None)
         if not store:
             return
-        dt = datetime.now()
+        dt = store.now()
         data = store.get_monthly_summary(dt.year, dt.month)
         self.month_view.set_stats(
             data["minutes_per_week"],


### PR DESCRIPTION
## Summary
- add `DeveloperOverlay` widget with speed toggle and day skip
- track virtual time in `DataStore` and add methods to shift/reset it
- separate daily achievements from session badges
- add developer menu integration in `MainWindow`
- use `DataStore.now()` throughout for date handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845472e4d7c832bbce882570acea33c