### PR TITLE
Fix data path for weekly stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The application now features a dynamic animated background that gently cycles th
 
 - Python 3.8+
 - PySide6
+- platformdirs
 
 Install dependencies in a virtual environment with the provided batch script.
 

--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -1,10 +1,16 @@
 import json
 from pathlib import Path
 from datetime import datetime, timedelta
+from platformdirs import user_data_dir
 
 
 class DataStore:
-    def __init__(self, path="calmio_data.json"):
+    def __init__(self, path: str | Path | None = None):
+        """Initialize the data store using a writable user data directory."""
+        if path is None:
+            data_dir = Path(user_data_dir("Calmio"))
+            data_dir.mkdir(parents=True, exist_ok=True)
+            path = data_dir / "calmio_data.json"
         self.path = Path(path)
         self.data = {
             "daily_seconds": {},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PySide6>=6.5
+platformdirs>=3.10


### PR DESCRIPTION
## Summary
- store app data in a user-writable directory using `platformdirs`
- document `platformdirs` dependency
- add `platformdirs` to requirements

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68454a40fab8832bba4b57ad104263ec