### PR TITLE
Fix weekly graph spacing and show short durations

### DIFF
--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -254,12 +254,13 @@ class DataStore:
 
         average = (total_seconds / 60) / 7 if total_seconds else 0
         return {
-            "minutes_per_day": [int(round(m)) for m in minutes_per_day],
+            "minutes_per_day": minutes_per_day,
             "total": total_seconds / 60,
             "average": average,
             "longest_day": longest_day,
             "longest_time": longest_time,
             "longest_minutes": longest_secs / 60,
+            "total_seconds": total_seconds,
         }
 
     def get_monthly_summary(self, year, month, goal=600):

--- a/calmio/weekly_stats.py
+++ b/calmio/weekly_stats.py
@@ -3,6 +3,18 @@ from PySide6.QtGui import QPainter, QColor, QFont
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel
 
 
+def format_duration(minutes: float) -> str:
+    """Return a human friendly time string for the given minutes."""
+    if minutes >= 60:
+        h = int(minutes // 60)
+        m = int(minutes % 60)
+        return f"{h}h" + (f" {m}m" if m else "")
+    if minutes >= 1:
+        return f"{int(minutes)}m"
+    secs = int(round(minutes * 60))
+    return f"{secs}s"
+
+
 class WeeklyBarGraph(QWidget):
     """Simple bar graph for weekly minutes."""
 
@@ -26,11 +38,12 @@ class WeeklyBarGraph(QWidget):
         h = self.height()
         top_margin = 20
         bottom_margin = 40
-        bar_width = w / 9
+        n = len(self.minutes)
+        bar_width = w / (1.5 * n)
         max_val = max(self.minutes) if max(self.minutes) > 0 else 1
 
         for i, m in enumerate(self.minutes):
-            x = (i * 2 + 1) * bar_width / 2 + i * bar_width / 2
+            x = ((3 * i + 1) / 2) * bar_width
             bar_h = (m / max_val) * (h - top_margin - bottom_margin)
             y = h - bottom_margin - bar_h
             color = QColor("#CBE8F4") if i % 2 == 0 else QColor("#FADDCB")
@@ -46,7 +59,7 @@ class WeeklyBarGraph(QWidget):
             painter.drawText(
                 QRectF(x, y - 18, bar_width, 16),
                 Qt.AlignHCenter | Qt.AlignBottom,
-                str(int(m)),
+                format_duration(m),
             )
             painter.drawText(
                 QRectF(x, h - bottom_margin, bar_width, bottom_margin),
@@ -81,11 +94,11 @@ class WeeklyStatsView(QWidget):
 
     def set_stats(self, minutes_per_day, total, average, longest_day, longest_time, longest_minutes):
         self.graph.set_minutes(minutes_per_day)
-        self.total_lbl.setText(f"Total esta semana: {int(total)} min")
-        self.avg_lbl.setText(f"Promedio diario: {average:.1f} min")
+        self.total_lbl.setText(f"Total esta semana: {format_duration(total)}")
+        self.avg_lbl.setText(f"Promedio diario: {format_duration(average)}")
         if longest_day:
             self.longest_lbl.setText(
-                f"Sesi\u00f3n m\u00e1s larga: {longest_day} {longest_time} – {int(longest_minutes)} min"
+                f"Sesi\u00f3n m\u00e1s larga: {longest_day} {longest_time} – {format_duration(longest_minutes)}"
             )
         else:
             self.longest_lbl.setText("Sesi\u00f3n m\u00e1s larga: --")


### PR DESCRIPTION
## Summary
- fix bar chart spacing so all seven days appear
- add helper to format durations in weeks graph
- show seconds and hours where appropriate
- keep fractional minutes in weekly summaries

## Testing
- `python -m py_compile calmio/data_store.py calmio/weekly_stats.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68454c5ab0e4832b8ae9d6853f462b12