### PR TITLE
Fix stats tab after session

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -542,6 +542,9 @@ class MainWindow(QMainWindow):
 
     def on_session_complete_done(self):
         self.stack.setCurrentWidget(self.main_view)
+        # Always reset to today's stats when showing the overlay after a
+        # session completes, regardless of the previously selected tab.
+        self.stats_overlay.show_tab(0)
         self.stats_overlay.show()
         self.stats_overlay.raise_()
         self.circle.breath_count = 0


### PR DESCRIPTION
## Summary
- reset stats overlay to the Today tab when closing the session complete view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68454dbd9ee8832bbf6197a07e348719