### PR TITLE
Improve background rings rotation

### DIFF
--- a/calmio/animated_background.py
+++ b/calmio/animated_background.py
@@ -29,10 +29,11 @@ class AnimatedBackground(QWidget):
 
         self._angle = 0.0
         # Three halo rings rotating around the breathing circle
+        # Increase spacing between rings and rotate all in the same direction
         self._rings = [
-            {"radius": 0.35, "phase": 0.0, "speed": 0.002, "dir": 1},   # inner ring
-            {"radius": 0.45, "phase": 1.0, "speed": 0.001, "dir": -1},  # middle ring
-            {"radius": 0.55, "phase": 2.0, "speed": 0.003, "dir": 1},   # outer ring
+            {"radius": 0.30, "phase": 0.0, "speed": 0.002, "dir": 1},  # inner ring
+            {"radius": 0.50, "phase": 1.0, "speed": 0.0015, "dir": 1},  # middle ring
+            {"radius": 0.70, "phase": 2.0, "speed": 0.003, "dir": 1},  # outer ring
         ]
         self._offset_timer = QTimer(self)
         self._offset_timer.timeout.connect(self._update_offset)


### PR DESCRIPTION
## Summary
- tweak ring sizes and speeds in `AnimatedBackground`
- rotate all rings clockwise and increase spacing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68454fb31d2c832b919c3ebaf190cabc