### PR TITLE
Fix background color reset for new session

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -270,6 +270,10 @@ class MainWindow(QMainWindow):
             self.session_seconds = 0
             self.cycle_durations = []
             self.stop_prompt_animation()
+            # Reset background color cycle for a new session
+            self._chakra_index = 0
+            if hasattr(self, "bg"):
+                self.bg.transition_to_index(0, duration=0)
         self.cycle_start = time.perf_counter()
 
         if (


### PR DESCRIPTION
## Summary
- ensure background color cycle resets on a new session start

## Testing
- `python -m py_compile calmio/main_window.py calmio/animated_background.py`


------
https://chatgpt.com/codex/tasks/task_e_6845d7614d84832b93ba17b6bd12f237