### PR TITLE
Limit monthly stats to four weeks

### DIFF
--- a/calmio/monthly_stats.py
+++ b/calmio/monthly_stats.py
@@ -2,6 +2,8 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QColor, QFont, QPainterPath, QPen
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QHBoxLayout
 
+from .weekly_stats import format_duration
+
 
 class MonthlyLineGraph(QWidget):
     """Smooth line graph for weekly minutes."""
@@ -57,6 +59,18 @@ class MonthlyLineGraph(QWidget):
         painter.setPen(pen)
         painter.setBrush(Qt.NoBrush)
         painter.drawPath(path)
+
+        # draw value labels above each peak
+        value_font = QFont("Sans Serif")
+        value_font.setPointSize(9)
+        painter.setFont(value_font)
+        painter.setPen(QColor("#333"))
+        for (x, y), minutes in zip(points, self.minutes):
+            painter.drawText(
+                QRectF(x - step / 2, y - 20, step, 16),
+                Qt.AlignHCenter | Qt.AlignBottom,
+                format_duration(minutes),
+            )
 
         label_font = QFont("Sans Serif")
         label_font.setPointSize(10)

--- a/calmio/stats_overlay.py
+++ b/calmio/stats_overlay.py
@@ -259,11 +259,13 @@ class StatsOverlay(QWidget):
             return
         dt = store.now()
         data = store.get_monthly_summary(dt.year, dt.month)
+        weeks = data["minutes_per_week"][:4]
+        best_idx = weeks.index(max(weeks)) + 1 if weeks else 0
         self.month_view.set_stats(
-            data["minutes_per_week"],
+            weeks,
             data["total"],
             data["average"],
-            data["best_week"],
+            best_idx,
             data["longest_streak"],
             data.get("goal", 600),
         )


### PR DESCRIPTION
## Summary
- display only last four weeks in monthly view
- show formatted duration above each peak in the monthly graph

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e7270a48832bbc644dbc2821c762