### PR TITLE
Fix QColor import in message_utils

### DIFF
--- a/calmio/message_utils.py
+++ b/calmio/message_utils.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
-from PySide6.QtCore import QEasingCurve, QPropertyAnimation, QSequentialAnimationGroup, QVariantAnimation, QColor
+from PySide6.QtCore import QEasingCurve, QPropertyAnimation, QSequentialAnimationGroup, QVariantAnimation
+from PySide6.QtGui import QColor
 
 
 class MessageHandler:


### PR DESCRIPTION
## Summary
- fix path for QColor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fd567924832b8b8dd9d7324ae4f5