### PR TITLE
Add basic DataStore unit tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,21 @@
+name: Python package
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from datetime import datetime, date
+
+import pytest
+
+# Import DataStore without triggering heavy package imports
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "calmio"))
+from data_store import DataStore
+
+
+def test_add_session_and_streak(tmp_path):
+    data_file = tmp_path / "data.json"
+    ds = DataStore(data_file)
+    start1 = datetime(2023, 1, 1, 8, 0)
+    ds.add_session(start1, seconds=60, breaths=5, inhale=3, exhale=3)
+
+    # verify first session stored
+    day_key = start1.date().isoformat()
+    assert ds.data["daily_seconds"][day_key] == 60
+    assert ds.get_sessions_for_date(start1)[0]["duration"] == 60
+
+    # add second session on next day to update streak
+    start2 = datetime(2023, 1, 2, 9, 0)
+    ds.add_session(start2, seconds=120, breaths=6, inhale=3, exhale=3)
+    assert ds.get_streak() == 2
+    assert ds.get_last_session()["duration"] == 120
+    assert len(ds.get_sessions_for_date(start2)) == 1
+
+
+def test_weekly_summary(tmp_path):
+    data_file = tmp_path / "data.json"
+    ds = DataStore(data_file)
+
+    sessions = [
+        (datetime(2023, 5, 1, 10, 0), 120),  # Monday
+        (datetime(2023, 5, 2, 11, 0), 300),  # Tuesday
+        (datetime(2023, 5, 3, 9, 0), 60),    # Wednesday
+        (datetime(2023, 5, 4, 20, 0), 180),  # Thursday
+        (datetime(2023, 5, 5, 14, 0), 90),   # Friday
+        # Saturday - no session
+        (datetime(2023, 5, 7, 18, 0), 240),  # Sunday
+    ]
+    for dt, secs in sessions:
+        ds.add_session(dt, seconds=secs, breaths=1, inhale=3, exhale=3)
+
+    summary = ds.get_weekly_summary(date(2023, 5, 7))
+
+    assert summary["minutes_per_day"] == pytest.approx([2, 5, 1, 3, 1.5, 0, 4])
+    assert summary["total"] == pytest.approx(16.5)
+    assert summary["average"] == pytest.approx(16.5 / 7)
+    assert summary["longest_day"] == "Martes"
+    assert summary["longest_time"] == "11:00"
+    assert summary["longest_minutes"] == pytest.approx(5)
+    assert summary["total_seconds"] == 990


### PR DESCRIPTION
## Summary
- add pytest-based tests for DataStore
- ensure GitHub Actions runs tests automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460699061c832bb234f0eda4845291