### PR TITLE
Implement breathing sound effects and music mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,14 @@ El overlay de estadísticas (`stats_overlay.py`) muestra diferentes pestañas ge
 ## Sistema de sonido opcional
 
 - El overlay `SoundOverlay` permite activar un ambiente (bosque, lluvia, fuego o mar).
-- Se puede activar un tono musical continuo y una campana que suena cada 10 respiraciones.
+- También puede activarse un **modo música** que reproduce la nota `notado.mp3`
+  cambiando el tono en cada respiración (DO, RE, MI, FA, SOL, LA, SI, DO).
+- Al llegar al punto máximo de cada inhalación suena `drop.mp3`.
+- Una campana con fundido de salida suave (`bell.mp3`) se reproduce cada 10 respiraciones.
 - Dos sliders controlan el volumen general y el de la campana.
 - El botón **Silenciar todo** detiene cualquier sonido en reproducción.
+- Los archivos `bosque.mp3`, `LLUVIA.mp3`, `fuego.mp3`, `mar.mp3`, `notado.mp3`,
+  `bell.mp3` y `drop.mp3` deben ubicarse en `assets/sounds/`.
 
 ## Modo desarrollador
 

--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -65,6 +65,7 @@ class BreathCircle(QWidget):
         self.breath_started_callback = None
         self.breath_finished_callback = None
         self.exhale_started_callback = None
+        self.inhale_finished_callback = None
         self.ripple_spawned_callback = None
         self.breath_start_time = 0
         self.inhale_start_time = 0
@@ -242,6 +243,8 @@ class BreathCircle(QWidget):
             self.phase = 'idle'
         elif self.phase == 'inhaling':
             self.start_ripple()
+            if self.inhale_finished_callback:
+                self.inhale_finished_callback()
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -90,6 +90,9 @@ class MainWindow(QMainWindow):
         self.circle.breath_finished_callback = self.session_manager.on_breath_end
         self.circle.exhale_started_callback = self.session_manager.on_exhale_start
         self.circle.ripple_spawned_callback = self.session_manager.start_waves
+        self.circle.inhale_finished_callback = (
+            self.sound_manager.play_drop
+        )
         self.update_speed()
 
         font = QFont("Sans Serif")
@@ -268,6 +271,7 @@ class MainWindow(QMainWindow):
         self.check_motivational_message(count)
         if hasattr(self, "sound_manager"):
             self.sound_manager.maybe_play_bell(count)
+            self.sound_manager.maybe_play_music(count)
         index = self._chakra_index_for_count(count)
         if getattr(self, "_chakra_index", None) != index:
             self._chakra_index = index

--- a/calmio/sound_overlay.py
+++ b/calmio/sound_overlay.py
@@ -71,8 +71,8 @@ class SoundOverlay(QWidget):
             layout.addWidget(rb)
         self.env_group.buttonClicked.connect(self._on_env_changed)
 
-        self.music_chk = QCheckBox("Modo m\u00fasica")
-        self.bell_chk = QCheckBox("Campana cada 10 respiraciones")
+        self.music_chk = QCheckBox("\U0001F3B9 Modo m\u00fasica")
+        self.bell_chk = QCheckBox("\U0001F514 Campana cada 10 respiraciones")
         self.music_chk.toggled.connect(self.music_toggled.emit)
         self.bell_chk.toggled.connect(self.bell_toggled.emit)
         layout.addWidget(self.music_chk)


### PR DESCRIPTION
## Summary
- add new sound files to the manager and play drop sound at inhale peak
- cycle through pitched notes of notado.mp3 on every breath
- fade out the bell and stop background ambience when music starts
- expose new options with icons on the sound overlay
- document required sound files and behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684627c731d0832bbf634b68a38cbfeb