### PR TITLE
Persist sound mode settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ El overlay de estadísticas (`stats_overlay.py`) muestra diferentes pestañas ge
   cambiando el tono en cada respiración (DO, RE, MI, FA, SOL, LA, SI, DO).
 - Al llegar al punto máximo de cada inhalación suena `drop.mp3`.
 - Una campana con fundido de salida suave (`bell.mp3`) se reproduce cada 10 respiraciones.
+- Dos casillas permiten activar o desactivar tanto el modo música como la campana.
 - Dos sliders controlan el volumen general y el de la campana.
 - El botón **Silenciar todo** detiene cualquier sonido en reproducción.
 - Los archivos `bosque.mp3`, `LLUVIA.mp3`, `fuego.mp3`, `mar.mp3`, `notado.mp3`,

--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -21,6 +21,10 @@ class DataStore:
             "badges": {},
             # badges earned today {date: {code: count}}
             "daily_badges": {},
+            "sound_settings": {
+                "music_enabled": False,
+                "bell_enabled": False,
+            },
         }
         self.time_offset = timedelta()
         self.load()
@@ -64,12 +68,25 @@ class DataStore:
                                 for b in v:
                                     counts[b] = counts.get(b, 0) + 1
                                 self.data["daily_badges"][k] = counts
+                    if "sound_settings" not in self.data:
+                        self.data["sound_settings"] = {
+                            "music_enabled": False,
+                            "bell_enabled": False,
+                        }
             except (json.JSONDecodeError, IOError):
                 pass
 
     def save(self):
         with self.path.open("w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2)
+
+    # ------------------------------------------------------------------
+    def get_sound_setting(self, name: str, default=None):
+        return self.data.get("sound_settings", {}).get(name, default)
+
+    def set_sound_setting(self, name: str, value) -> None:
+        self.data.setdefault("sound_settings", {})[name] = value
+        self.save()
 
     def add_session(self, start_dt, seconds, breaths, inhale, exhale, cycles=None):
         date_key = start_dt.date().isoformat()
@@ -325,5 +342,9 @@ class DataStore:
             "sessions": [],
             "badges": {},
             "daily_badges": {},
+            "sound_settings": {
+                "music_enabled": False,
+                "bell_enabled": False,
+            },
         }
         self.save()

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -239,6 +239,19 @@ class MainWindow(QMainWindow):
         self.sound_overlay.mute_all.connect(self.sound_manager.mute_all)
         self.sound_button.clicked.connect(self.menu_handler.toggle_sound)
 
+        music_enabled = self.data_store.get_sound_setting("music_enabled", False)
+        bell_enabled = self.data_store.get_sound_setting("bell_enabled", False)
+        self.sound_overlay.music_chk.setChecked(music_enabled)
+        self.sound_overlay.bell_chk.setChecked(bell_enabled)
+        self.sound_manager.set_music_enabled(music_enabled)
+        self.sound_manager.set_bell_enabled(bell_enabled)
+        self.sound_overlay.music_toggled.connect(
+            lambda v: self.data_store.set_sound_setting("music_enabled", v)
+        )
+        self.sound_overlay.bell_toggled.connect(
+            lambda v: self.data_store.set_sound_setting("bell_enabled", v)
+        )
+
         # Initialize overlay with stored data
         self.stats_overlay.update_minutes(self.meditation_seconds)
         last = self.data_store.get_last_session()


### PR DESCRIPTION
## Summary
- persist state of music mode and bell toggle in DataStore
- restore these settings on startup
- mention sound toggles in README

## Testing
- `python -m py_compile calmio/*.py`
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684629d1f31c832b958a0cdccacc3aa9