### PR TITLE
Add music and drop volume controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ El overlay de estadísticas (`stats_overlay.py`) muestra diferentes pestañas ge
   cambiando el tono en cada respiración (DO, RE, MI, FA, SOL, LA, SI, DO).
 - Al llegar al punto máximo de cada inhalación suena `drop.mp3`.
 - Una campana con fundido de salida suave (`bell.mp3`) se reproduce cada 10 respiraciones.
-- Dos casillas permiten activar o desactivar tanto el modo música como la campana.
-- Dos sliders controlan el volumen general y el de la campana.
+- Dos casillas (con indicación ON/OFF) permiten activar o desactivar tanto el modo música como la campana.
+- Se agregaron deslizadores de volumen independientes para el modo música y para el sonido `drop`, además de los controles general y de campana.
 - El botón **Silenciar todo** detiene cualquier sonido en reproducción.
 - Los archivos `bosque.mp3`, `LLUVIA.mp3`, `fuego.mp3`, `mar.mp3`, `notado.mp3`,
   `bell.mp3` y `drop.mp3` deben ubicarse en `assets/sounds/`.

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -236,6 +236,8 @@ class MainWindow(QMainWindow):
         self.sound_overlay.bell_toggled.connect(self.sound_manager.set_bell_enabled)
         self.sound_overlay.volume_changed.connect(self.sound_manager.set_volume)
         self.sound_overlay.bell_volume_changed.connect(self.sound_manager.set_bell_volume)
+        self.sound_overlay.music_volume_changed.connect(self.sound_manager.set_music_volume)
+        self.sound_overlay.drop_volume_changed.connect(self.sound_manager.set_drop_volume)
         self.sound_overlay.mute_all.connect(self.sound_manager.mute_all)
         self.sound_button.clicked.connect(self.menu_handler.toggle_sound)
 

--- a/calmio/sound_overlay.py
+++ b/calmio/sound_overlay.py
@@ -22,6 +22,8 @@ class SoundOverlay(QWidget):
     bell_toggled = Signal(bool)
     volume_changed = Signal(int)
     bell_volume_changed = Signal(int)
+    music_volume_changed = Signal(int)
+    drop_volume_changed = Signal(int)
     mute_all = Signal()
 
     def __init__(self, parent=None):
@@ -71,10 +73,14 @@ class SoundOverlay(QWidget):
             layout.addWidget(rb)
         self.env_group.buttonClicked.connect(self._on_env_changed)
 
-        self.music_chk = QCheckBox("\U0001F3B9 Modo m\u00fasica")
-        self.bell_chk = QCheckBox("\U0001F514 Campana cada 10 respiraciones")
+        self.music_chk = QCheckBox("\U0001F3B9 Modo m\u00fasica [OFF]")
+        self.bell_chk = QCheckBox("\U0001F514 Campana cada 10 [OFF]")
         self.music_chk.toggled.connect(self.music_toggled.emit)
         self.bell_chk.toggled.connect(self.bell_toggled.emit)
+        self.music_chk.toggled.connect(self._update_music_label)
+        self.bell_chk.toggled.connect(self._update_bell_label)
+        self._update_music_label(self.music_chk.isChecked())
+        self._update_bell_label(self.bell_chk.isChecked())
         layout.addWidget(self.music_chk)
         layout.addWidget(self.bell_chk)
 
@@ -92,6 +98,20 @@ class SoundOverlay(QWidget):
         self.bell_slider.valueChanged.connect(self.bell_volume_changed.emit)
         layout.addWidget(self.bell_slider)
 
+        layout.addWidget(QLabel("Volumen m\u00fasica"))
+        self.music_slider = QSlider(Qt.Horizontal)
+        self.music_slider.setRange(0, 100)
+        self.music_slider.setValue(50)
+        self.music_slider.valueChanged.connect(self.music_volume_changed.emit)
+        layout.addWidget(self.music_slider)
+
+        layout.addWidget(QLabel("Volumen drop"))
+        self.drop_slider = QSlider(Qt.Horizontal)
+        self.drop_slider.setRange(0, 100)
+        self.drop_slider.setValue(50)
+        self.drop_slider.valueChanged.connect(self.drop_volume_changed.emit)
+        layout.addWidget(self.drop_slider)
+
         self.mute_btn = QPushButton("Silenciar todo")
         self.mute_btn.setStyleSheet(
             "QPushButton{" "background-color:#CCE4FF;border:none;border-radius:20px;"
@@ -101,6 +121,14 @@ class SoundOverlay(QWidget):
         layout.addWidget(self.mute_btn, alignment=Qt.AlignCenter)
 
         layout.addStretch()
+
+    def _update_music_label(self, checked: bool) -> None:
+        state = "ON" if checked else "OFF"
+        self.music_chk.setText(f"\U0001F3B9 Modo m\u00fasica [{state}]")
+
+    def _update_bell_label(self, checked: bool) -> None:
+        state = "ON" if checked else "OFF"
+        self.bell_chk.setText(f"\U0001F514 Campana cada 10 [{state}]")
 
     def _on_env_changed(self):
         if self.env_bosque.isChecked():


### PR DESCRIPTION
## Summary
- show ON/OFF state in music and bell checkboxes
- allow music mode alongside ambient sounds
- add volume sliders for music and drop sounds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462c41e4e8832b8d02547d09431dfd