### PR TITLE
Implement harmonic music mode

### DIFF
--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -24,6 +24,8 @@ class DataStore:
             "sound_settings": {
                 "music_enabled": False,
                 "bell_enabled": False,
+                "music_mode": "scale",
+                "scale_type": "major",
             },
         }
         self.time_offset = timedelta()
@@ -72,7 +74,12 @@ class DataStore:
                         self.data["sound_settings"] = {
                             "music_enabled": False,
                             "bell_enabled": False,
+                            "music_mode": "scale",
+                            "scale_type": "major",
                         }
+                    else:
+                        self.data["sound_settings"].setdefault("music_mode", "scale")
+                        self.data["sound_settings"].setdefault("scale_type", "major")
             except (json.JSONDecodeError, IOError):
                 pass
 
@@ -345,6 +352,8 @@ class DataStore:
             "sound_settings": {
                 "music_enabled": False,
                 "bell_enabled": False,
+                "music_mode": "scale",
+                "scale_type": "major",
             },
         }
         self.save()

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -239,12 +239,20 @@ class MainWindow(QMainWindow):
         self.sound_overlay.music_volume_changed.connect(self.sound_manager.set_music_volume)
         self.sound_overlay.drop_volume_changed.connect(self.sound_manager.set_drop_volume)
         self.sound_overlay.mute_all.connect(self.sound_manager.mute_all)
+        self.sound_overlay.music_mode_changed.connect(self.sound_manager.set_music_mode)
+        self.sound_overlay.scale_changed.connect(self.sound_manager.set_scale_type)
         self.sound_button.clicked.connect(self.menu_handler.toggle_sound)
 
         music_enabled = self.data_store.get_sound_setting("music_enabled", False)
         bell_enabled = self.data_store.get_sound_setting("bell_enabled", False)
         self.sound_overlay.music_chk.setChecked(music_enabled)
         self.sound_overlay.bell_chk.setChecked(bell_enabled)
+        mode = self.data_store.get_sound_setting("music_mode", "scale")
+        scale = self.data_store.get_sound_setting("scale_type", "major")
+        self.sound_overlay.set_music_mode(mode)
+        self.sound_overlay.set_scale_type(scale)
+        self.sound_manager.set_music_mode(mode)
+        self.sound_manager.set_scale_type(scale)
         self.sound_manager.set_music_enabled(music_enabled)
         self.sound_manager.set_bell_enabled(bell_enabled)
         self.sound_overlay.music_toggled.connect(
@@ -252,6 +260,12 @@ class MainWindow(QMainWindow):
         )
         self.sound_overlay.bell_toggled.connect(
             lambda v: self.data_store.set_sound_setting("bell_enabled", v)
+        )
+        self.sound_overlay.music_mode_changed.connect(
+            lambda v: self.data_store.set_sound_setting("music_mode", v)
+        )
+        self.sound_overlay.scale_changed.connect(
+            lambda v: self.data_store.set_sound_setting("scale_type", v)
         )
 
         # Initialize overlay with stored data


### PR DESCRIPTION
## Summary
- expand music options with dropdown for scale or harmonic mode
- add major/minor scale toggle
- persist music mode and scale type settings
- generate scale or harmonic melodies with fade out

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684630914ce4832ba7bd3d48a8fab576