### PR TITLE
Add guided breath modes overlay

### DIFF
--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -8,6 +8,7 @@ from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .options_overlay import OptionsOverlay
 from .sound_overlay import SoundOverlay
+from .breath_modes_overlay import BreathModesOverlay
 from .main_window import MainWindow
 from .animated_background import AnimatedBackground
 from .wave_overlay import WaveOverlay
@@ -26,6 +27,7 @@ __all__ = [
     "SessionDetailsView",
     "OptionsOverlay",
     "SoundOverlay",
+    "BreathModesOverlay",
     "MainWindow",
     "AnimatedBackground",
     "WaveOverlay",

--- a/calmio/breath_modes_overlay.py
+++ b/calmio/breath_modes_overlay.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QHBoxLayout,
+    QPushButton,
+    QFrame,
+    QScrollArea,
+)
+import json
+from pathlib import Path
+
+
+class BreathModesOverlay(QWidget):
+    """Overlay listing scientific breathing patterns."""
+
+    back_requested = Signal()
+    pattern_selected = Signal(dict)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setStyleSheet(
+            "background-color:#FAFAFA;border-radius:20px;color:#444;"
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.scroll = QScrollArea()
+        self.scroll.setWidgetResizable(True)
+        self.scroll.setStyleSheet("QScrollArea{border:none;}")
+        layout.addWidget(self.scroll)
+
+        container = QWidget()
+        self.scroll.setWidget(container)
+        c_layout = QVBoxLayout(container)
+        c_layout.setContentsMargins(20, 20, 20, 20)
+        c_layout.setSpacing(15)
+
+        header = QHBoxLayout()
+        self.back_btn = QPushButton("\u2190")
+        self.back_btn.setStyleSheet(
+            "QPushButton{background:none;border:none;font-size:18px;}"
+        )
+        self.back_btn.clicked.connect(self.back_requested.emit)
+        header.addWidget(self.back_btn, alignment=Qt.AlignLeft)
+
+        title = QLabel("Modos de respiración")
+        t_font = QFont("Sans Serif")
+        t_font.setPointSize(20)
+        t_font.setWeight(QFont.Medium)
+        title.setFont(t_font)
+        title.setAlignment(Qt.AlignCenter)
+        header.addWidget(title, alignment=Qt.AlignCenter)
+        header.addStretch()
+        c_layout.addLayout(header)
+
+        self.pattern_container = QVBoxLayout()
+        self.pattern_container.setSpacing(10)
+        c_layout.addLayout(self.pattern_container)
+        c_layout.addStretch()
+
+        self._load_patterns()
+
+    def _load_patterns(self):
+        patterns_file = Path(__file__).with_name("breath_patterns.json")
+        try:
+            data = json.loads(patterns_file.read_text(encoding="utf-8"))
+        except Exception:
+            data = []
+        for pat in data:
+            self._add_pattern_row(pat)
+
+    def _add_pattern_row(self, pat: dict) -> None:
+        row = QFrame()
+        row.setStyleSheet(
+            "background:white;border-radius:15px;padding:10px;"
+        )
+        r_layout = QHBoxLayout(row)
+        name_lbl = QLabel(pat.get("name", ""))
+        name_font = QFont("Sans Serif")
+        name_font.setPointSize(14)
+        name_lbl.setFont(name_font)
+        desc = pat.get("description", "")
+        count_str = " / ".join(str(p.get("duration", 0)) for p in pat.get("phases", []))
+        info_lbl = QLabel(f"{count_str}s – {desc}")
+        info_lbl.setWordWrap(True)
+        sel_btn = QPushButton("Usar")
+        sel_btn.setStyleSheet(
+            "QPushButton{background-color:#CCE4FF;border:none;border-radius:10px;" "padding:6px 12px;}"
+        )
+        sel_btn.clicked.connect(lambda _, p=pat: self.pattern_selected.emit(p))
+        r_layout.addWidget(name_lbl)
+        r_layout.addStretch()
+        r_layout.addWidget(info_lbl)
+        r_layout.addWidget(sel_btn)
+        self.pattern_container.addWidget(row)
+
+

--- a/calmio/breath_patterns.json
+++ b/calmio/breath_patterns.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "free",
+    "name": "Libre",
+    "phases": [
+      {"name": "Inhalar", "duration": 4},
+      {"name": "Exhalar", "duration": 6}
+    ],
+    "description": "Respiración libre siguiendo el ritmo natural."
+  },
+  {
+    "id": "4-7-8",
+    "name": "4-7-8",
+    "phases": [
+      {"name": "Inhalar", "duration": 4},
+      {"name": "Retener", "duration": 7},
+      {"name": "Exhalar", "duration": 8}
+    ],
+    "description": "Reduce la ansiedad y mejora el sueño."
+  },
+  {
+    "id": "box",
+    "name": "Box Breathing",
+    "phases": [
+      {"name": "Inhalar", "duration": 4},
+      {"name": "Retener", "duration": 4},
+      {"name": "Exhalar", "duration": 4},
+      {"name": "Retener", "duration": 4}
+    ],
+    "description": "Mejora el enfoque y regula emociones."
+  },
+  {
+    "id": "coherence",
+    "name": "Coherencia Cardíaca",
+    "phases": [
+      {"name": "Inhalar", "duration": 6},
+      {"name": "Exhalar", "duration": 6}
+    ],
+    "description": "Sincroniza respiración y corazón."
+  },
+  {
+    "id": "4-6",
+    "name": "4-6",
+    "phases": [
+      {"name": "Inhalar", "duration": 4},
+      {"name": "Exhalar", "duration": 6}
+    ],
+    "description": "Relaja y libera tensión."
+  }
+]

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -23,6 +23,8 @@ class MenuHandler:
         ]
         if hasattr(self.window, "sound_button"):
             buttons.append(self.window.sound_button)
+        if hasattr(self.window, "patterns_button"):
+            buttons.append(self.window.patterns_button)
         for i, btn in enumerate(buttons, start=1):
             btn.move(x - i * (self.window.menu_button.width() + margin), y)
         if hasattr(self.window, "dev_menu"):
@@ -37,6 +39,8 @@ class MenuHandler:
             self.window.options_overlay.setGeometry(self.window.rect())
         if hasattr(self.window, "sound_overlay"):
             self.window.sound_overlay.setGeometry(self.window.rect())
+        if hasattr(self.window, "breath_modes"):
+            self.window.breath_modes.setGeometry(self.window.rect())
 
     def _setup_control_button(self, button: QPushButton) -> None:
         """Apply common styling to control buttons."""
@@ -80,6 +84,17 @@ class MenuHandler:
 
     def close_sound(self) -> None:
         self.window.sound_overlay.hide()
+        self.hide_control_buttons()
+
+    def toggle_breath_modes(self) -> None:
+        if self.window.breath_modes.isVisible():
+            self.close_breath_modes()
+        else:
+            self.window.breath_modes.show()
+            self.window.breath_modes.raise_()
+
+    def close_breath_modes(self) -> None:
+        self.window.breath_modes.hide()
         self.hide_control_buttons()
 
     def hide_control_buttons(self) -> None:


### PR DESCRIPTION
## Summary
- create `BreathModesOverlay` and JSON with scientific patterns
- export overlay in package
- allow `BreathCircle` to animate arbitrary breathing patterns with dynamic colours
- integrate new overlay and button in `MainWindow`
- update `MenuHandler` to handle overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463b4528b4832ba61a2f488eb03202