### PR TITLE
Manual control of breathing patterns

### DIFF
--- a/calmio/breath_patterns.json
+++ b/calmio/breath_patterns.json
@@ -37,14 +37,5 @@
       {"name": "Exhalar", "duration": 6}
     ],
     "description": "Sincroniza respiración y corazón."
-  },
-  {
-    "id": "4-6",
-    "name": "4-6",
-    "phases": [
-      {"name": "Inhalar", "duration": 4},
-      {"name": "Exhalar", "duration": 6}
-    ],
-    "description": "Relaja y libera tensión."
   }
 ]

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -347,14 +347,14 @@ class MainWindow(QMainWindow):
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Space and not event.isAutoRepeat():
-            self.circle.start_inhale()
+            self.circle.on_press()
             event.accept()
         else:
             super().keyPressEvent(event)
 
     def keyReleaseEvent(self, event):
         if event.key() == Qt.Key_Space and not event.isAutoRepeat():
-            self.circle.start_exhale()
+            self.circle.on_release()
             event.accept()
         else:
             super().keyReleaseEvent(event)
@@ -527,5 +527,4 @@ class MainWindow(QMainWindow):
     def _on_pattern_selected(self, pattern: dict) -> None:
         phases = pattern.get("phases", [])
         self.circle.set_pattern(phases)
-        self.circle.start_pattern()
         self.menu_handler.close_breath_modes()


### PR DESCRIPTION
## Summary
- control breathing patterns via user input instead of auto playback
- drop the duplicate `4-6` pattern option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846401c98a8832bb284eeb5062f1015