### PR TITLE
Add timed hold phase for breathing patterns

### DIFF
--- a/calmio/breath_patterns.json
+++ b/calmio/breath_patterns.json
@@ -30,6 +30,16 @@
     "description": "Mejora el enfoque y regula emociones."
   },
   {
+    "id": "triple",
+    "name": "Tres Respiraciones",
+    "phases": [
+      {"name": "Inhalar", "duration": 3},
+      {"name": "Retener", "duration": 3},
+      {"name": "Exhalar", "duration": 3}
+    ],
+    "description": "Inhala, retén y suelta contando hasta tres."
+  },
+  {
     "id": "coherence",
     "name": "Coherencia Cardíaca",
     "phases": [


### PR DESCRIPTION
## Summary
- handle hold phases with a timer
- stop the timer when keys change
- include new "Tres Respiraciones" pattern

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684643f222a4832b9ba7775a3908a8b3