### PR TITLE
Add retention color transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ En Windows puede ejecutarse `run_app.bat`, el script creará un entorno virtual 
 - **Animaciones asociadas**
   - Expansión/contracción del radio mediante `QPropertyAnimation`.
   - Cambio de color entre el tono base y su complemento durante cada fase.
+  - La retención utiliza un tercer color para formar una triada equilibrada.
   - Efecto de anillo expansivo que se desvanece tras la exhalación.
 - **Interacciones**
   - El usuario puede pulsar el círculo o mantener la barra espaciadora para respirar.


### PR DESCRIPTION
## Summary
- add purple `retention_color` to complete a color triad
- animate color change during hold phases
- assign hold color in breathing patterns
- document new color behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684645b911e8832baae6cbe25984cbee