### PR TITLE
Fix triple breathing music

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -349,13 +349,19 @@ class BreathCircle(QWidget):
         if not self.pattern:
             self.start_exhale()
         else:
-            if self.hold_timer.isActive():
-                self.hold_timer.stop()
+            hold_active = self.hold_timer.isActive()
             if self.phase in ("inhaling", "holding"):
                 # Interrupt cycle and reset
+                # Call start_exhale before stopping the hold timer so the
+                # cycle is marked invalid when releasing early from a hold
+                self.released_during_exhale = True
                 self.start_exhale()
+                if hold_active:
+                    self.hold_timer.stop()
                 self.phase_index = 0
             else:
+                if hold_active:
+                    self.hold_timer.stop()
                 self._maybe_start_phase()
 
     def _maybe_start_phase(self):

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -308,11 +308,15 @@ class MainWindow(QMainWindow):
         """Handle breath count updates after a full cycle."""
         self.check_motivational_message(count)
         if hasattr(self, "sound_manager"):
-            skip_music = (
-                self.current_pattern_id == "triple"
-                and self.circle.released_during_exhale
-            )
-            if not skip_music:
+            play_music = True
+            if self.current_pattern_id == "triple":
+                # Only play a note after completing three full breaths
+                play_music = (
+                    count % 3 == 0 and not self.circle.released_during_exhale
+                )
+            elif self.circle.released_during_exhale:
+                play_music = False
+            if play_music:
                 self.sound_manager.maybe_play_music(count)
             self.circle.released_during_exhale = False
         index = self._chakra_index_for_count(count)


### PR DESCRIPTION
## Summary
- prevent music from playing for incomplete triple breath cycles
- only play a note every third completed breath

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684651aaa70c832b99b3499bb7bda735