### PR TITLE
Fix exhale animation speed after early release

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -351,6 +351,9 @@ class BreathCircle(QWidget):
         self.key_pressed = False
         if self.phase == "exhaling" and self.animation:
             self.released_during_exhale = True
+            if not self.pattern:
+                # Keep current exhale animation so it matches pattern behavior
+                return
         if not self.pattern:
             self.start_exhale()
         else:


### PR DESCRIPTION
## Summary
- avoid resetting exhale animation if the user releases while already exhaling

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684656a1d18c832ba1f4dc1451b79c4e