### PR TITLE
Add ripple after exhale for box breathing

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -417,6 +417,9 @@ class BreathCircle(QWidget):
             if self.inhale_finished_callback:
                 self.inhale_finished_callback()
         elif self.phase == 'exhaling':
+            # Trigger a ripple when the exhale completes so the user
+            # knows the contraction finished (used by box breathing)
+            self.start_ripple()
             if self.cycle_valid:
                 exhale_end = time.perf_counter()
                 duration = exhale_end - self.breath_start_time


### PR DESCRIPTION
## Summary
- trigger ripple when exhale animation finishes so box breathing shows waves at each step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465a5a4cd0832baeac0949d0d4a2ad