### PR TITLE
Enable key hold through box breathing exhale

### DIFF
--- a/calmio/breath_patterns.json
+++ b/calmio/breath_patterns.json
@@ -22,10 +22,10 @@
     "id": "box",
     "name": "Box Breathing",
     "phases": [
-      {"name": "Inhalar", "duration": 4},
-      {"name": "Retener", "duration": 4},
-      {"name": "Exhalar", "duration": 4},
-      {"name": "Retener", "duration": 4}
+      {"name": "Inhalar", "duration": 4, "press": true},
+      {"name": "Retener", "duration": 4, "press": true},
+      {"name": "Exhalar", "duration": 4, "press": true, "end_fraction": 0.5},
+      {"name": "Retener", "duration": 4, "press": false, "end_fraction": 0.0}
     ],
     "description": "Mejora el enfoque y regula emociones."
   },


### PR DESCRIPTION
## Summary
- allow specifying whether the key should be pressed per breathing phase
- support custom end radius for inhale, exhale and hold phases
- update `box` breathing pattern to keep key pressed through exhale

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465cf6d28c832ba7fefdbeab1ee1cd