### PR TITLE
Handle box breathing sound cue

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -342,8 +342,10 @@ class BreathCircle(QWidget):
             self.hold_timer.stop()
 
     def _on_hold_finished(self):
+        current = self.phase_index
         self.start_ripple()
-        if self.inhale_finished_callback:
+        if current == len(self.pattern) - 1 and self.inhale_finished_callback:
+            # Only trigger the cue when the final hold of the pattern ends
             self.inhale_finished_callback()
         self.phase_index += 1
         if self.phase_index >= len(self.pattern):

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -314,6 +314,11 @@ class MainWindow(QMainWindow):
                 play_music = (
                     count % 3 == 0 and not self.circle.released_during_exhale
                 )
+            elif self.current_pattern_id == "box":
+                # Play note only when the four-phase box cycle completes
+                play_music = (
+                    count % 4 == 0 and not self.circle.released_during_exhale
+                )
             elif self.circle.released_during_exhale:
                 play_music = False
             if play_music:


### PR DESCRIPTION
## Summary
- trigger inhale callback only after final hold in breathing patterns
- play music note only once per completed box breathing cycle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465effcd78832bb6a772f41efd4fad