### PR TITLE
Improve drop cues on phase transitions

### DIFF
--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -435,17 +435,17 @@ class BreathCircle(QWidget):
             pass
         if self.phase == 'inhaling':
             self.start_ripple()
-            next_is_hold = False
-            if self.pattern:
-                next_index = (self.phase_index + 1) % len(self.pattern)
-                next_name = self.pattern[next_index].get("name", "").lower()
-                next_is_hold = "ret" in next_name or "hold" in next_name
-            if not next_is_hold and self.inhale_finished_callback:
+            if self.inhale_finished_callback:
                 self.inhale_finished_callback()
         elif self.phase == 'exhaling':
             # Trigger a ripple when the exhale completes so the user
             # knows the contraction finished (used by box breathing)
             self.start_ripple()
+            next_is_hold = False
+            if self.pattern:
+                next_index = (self.phase_index + 1) % len(self.pattern)
+                next_name = self.pattern[next_index].get("name", "").lower()
+                next_is_hold = "ret" in next_name or "hold" in next_name
             if self.cycle_valid:
                 exhale_end = time.perf_counter()
                 duration = exhale_end - self.breath_start_time
@@ -460,6 +460,8 @@ class BreathCircle(QWidget):
                     self.breath_finished_callback(duration, inhale_dur, exhale_dur)
             self.breath_start_time = 0
             self.phase = 'idle'
+            if next_is_hold and self.inhale_finished_callback:
+                self.inhale_finished_callback()
         self.released_during_exhale = False
         self.phase_index += 1
         if self.phase_index >= len(self.pattern):

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -350,7 +350,7 @@ class MainWindow(QMainWindow):
         self.session_manager.on_exhale_start(duration)
 
     def on_inhale_finished(self):
-        """Handle actions when an inhale or final hold ends."""
+        """Handle actions when a breathing phase ends."""
         # During box breathing play the musical note when the last hold
         # completes instead of the usual drop cue.
         if (


### PR DESCRIPTION
## Summary
- trigger `on_inhale_finished` after every phase to play a drop
- play drop at the end of exhales when a hold follows
- update docstring about phase completion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684664f64cac832ba1bef8c85013bb01