### PR TITLE
Fix label color sync across breathing phases

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -91,6 +91,7 @@ class MainWindow(QMainWindow):
         self.circle.breath_started_callback = self.session_manager.on_breath_start
         self.circle.breath_finished_callback = self.session_manager.on_breath_end
         self.circle.exhale_started_callback = self.session_manager.on_exhale_start
+        self.circle.hold_started_callback = self.session_manager.on_hold_start
         self.circle.ripple_spawned_callback = self.session_manager.start_waves
         self.circle.inhale_finished_callback = self.on_inhale_finished
         self.update_speed()
@@ -104,6 +105,7 @@ class MainWindow(QMainWindow):
         self.label.setStyleSheet("color:white;")
         self.base_text_color = QColor("white")
         self.active_text_color = self.circle.complement_color
+        self.current_text_color = self.base_text_color
         self.text_color_anim = None
         self.count_opacity = QGraphicsOpacityEffect(self.label)
         self.label.setGraphicsEffect(self.count_opacity)
@@ -343,11 +345,14 @@ class MainWindow(QMainWindow):
     def start_waves(self, center, color):
         self.session_manager.start_waves(center, color)
 
-    def on_breath_start(self):
-        self.session_manager.on_breath_start()
+    def on_breath_start(self, color, duration):
+        self.session_manager.on_breath_start(color, duration)
 
-    def on_exhale_start(self, duration):
-        self.session_manager.on_exhale_start(duration)
+    def on_exhale_start(self, duration, color):
+        self.session_manager.on_exhale_start(duration, color)
+
+    def on_hold_start(self, duration, color):
+        self.session_manager.on_hold_start(duration, color)
 
     def on_inhale_finished(self):
         """Handle actions when a breathing phase ends."""
@@ -506,6 +511,7 @@ class MainWindow(QMainWindow):
     def _update_label_color(self, color):
         if isinstance(color, QColor):
             self.label.setStyleSheet(f"color:{color.name()};")
+            self.current_text_color = color
 
     def stop_prompt_animation(self):
         self.message_handler.stop_prompt_animation()

--- a/calmio/session_manager.py
+++ b/calmio/session_manager.py
@@ -19,7 +19,7 @@ class SessionManager:
         if hasattr(self.window, "wave_overlay"):
             self.window.wave_overlay.start_waves(center, color)
 
-    def on_breath_start(self):
+    def on_breath_start(self, color, duration):
         if not self.window.session_active:
             self.window.session_active = True
             self.window.session_start = self.window.data_store.now()
@@ -40,7 +40,7 @@ class SessionManager:
         self.window.label.setText(str(self.window.circle.breath_count + 1))
         self.window.count_opacity.setOpacity(0)
         self.window.count_anim = QPropertyAnimation(self.window.count_opacity, b"opacity", self.window)
-        self.window.count_anim.setDuration(int(self.window.circle.inhale_time))
+        self.window.count_anim.setDuration(int(duration))
         self.window.count_anim.setStartValue(0)
         self.window.count_anim.setEndValue(1)
         self.window.count_anim.start()
@@ -48,16 +48,16 @@ class SessionManager:
         if self.window.text_color_anim and self.window.text_color_anim.state() != QAbstractAnimation.Stopped:
             self.window.text_color_anim.stop()
         self.window.text_color_anim = QVariantAnimation(self.window)
-        self.window.text_color_anim.setDuration(int(self.window.circle.inhale_time))
-        self.window.text_color_anim.setStartValue(self.window.base_text_color)
-        self.window.text_color_anim.setEndValue(self.window.active_text_color)
+        self.window.text_color_anim.setDuration(int(duration))
+        self.window.text_color_anim.setStartValue(self.window.current_text_color)
+        self.window.text_color_anim.setEndValue(color)
         self.window.text_color_anim.valueChanged.connect(self.window._update_label_color)
         self.window.text_color_anim.start()
 
         if hasattr(self.window, "bg_anim") and self.window.bg_anim.state() != QAbstractAnimation.Stopped:
             self.window.bg_anim.stop()
         self.window.bg_anim = QPropertyAnimation(self.window.bg, b"opacity", self.window)
-        self.window.bg_anim.setDuration(int(self.window.circle.inhale_time))
+        self.window.bg_anim.setDuration(int(duration))
         self.window.bg_anim.setStartValue(self.window.bg.opacity)
         self.window.bg_anim.setEndValue(1.0)
         self.window.bg_anim.setEasingCurve(QEasingCurve.InOutSine)
@@ -66,13 +66,13 @@ class SessionManager:
         if hasattr(self.window, "bg_padding_anim") and self.window.bg_padding_anim.state() != QAbstractAnimation.Stopped:
             self.window.bg_padding_anim.stop()
         self.window.bg_padding_anim = QPropertyAnimation(self.window.bg, b"ring_padding", self.window)
-        self.window.bg_padding_anim.setDuration(int(self.window.circle.inhale_time))
+        self.window.bg_padding_anim.setDuration(int(duration))
         self.window.bg_padding_anim.setStartValue(self.window.bg.ring_padding)
         self.window.bg_padding_anim.setEndValue(1.25)
         self.window.bg_padding_anim.setEasingCurve(QEasingCurve.InOutSine)
         self.window.bg_padding_anim.start()
 
-    def on_exhale_start(self, duration):
+    def on_exhale_start(self, duration, color):
         if (
             hasattr(self.window, "count_anim")
             and self.window.count_anim.state() != QAbstractAnimation.Stopped
@@ -89,8 +89,8 @@ class SessionManager:
             self.window.text_color_anim.stop()
         self.window.text_color_anim = QVariantAnimation(self.window)
         self.window.text_color_anim.setDuration(int(duration))
-        self.window.text_color_anim.setStartValue(self.window.active_text_color)
-        self.window.text_color_anim.setEndValue(self.window.base_text_color)
+        self.window.text_color_anim.setStartValue(self.window.current_text_color)
+        self.window.text_color_anim.setEndValue(color)
         self.window.text_color_anim.valueChanged.connect(self.window._update_label_color)
         self.window.text_color_anim.start()
 
@@ -111,6 +111,16 @@ class SessionManager:
         self.window.bg_padding_anim.setEndValue(1.0)
         self.window.bg_padding_anim.setEasingCurve(QEasingCurve.InOutSine)
         self.window.bg_padding_anim.start()
+
+    def on_hold_start(self, duration, color):
+        if self.window.text_color_anim and self.window.text_color_anim.state() != QAbstractAnimation.Stopped:
+            self.window.text_color_anim.stop()
+        self.window.text_color_anim = QVariantAnimation(self.window)
+        self.window.text_color_anim.setDuration(int(duration))
+        self.window.text_color_anim.setStartValue(self.window.current_text_color)
+        self.window.text_color_anim.setEndValue(color)
+        self.window.text_color_anim.valueChanged.connect(self.window._update_label_color)
+        self.window.text_color_anim.start()
 
     def on_breath_end(self, duration, inhale, exhale):
         self.window.last_cycle_duration = duration


### PR DESCRIPTION
## Summary
- propagate color and duration info when breathing phases start
- animate label color to match circle color
- track current label color for subsequent animations
- add hold phase callback for color updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846688691f4832b8560cfb1fc155378