### PR TITLE
Add biofeedback overlay messages

### DIFF
--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -4,6 +4,7 @@ from .breath_circle import BreathCircle
 from .progress_circle import ProgressCircle
 from .stats_overlay import StatsOverlay
 from .session_complete import SessionComplete
+from .biofeedback_overlay import BioFeedbackOverlay
 from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .options_overlay import OptionsOverlay
@@ -36,4 +37,5 @@ __all__ = [
     "OverlayManager",
     "MessageHandler",
     "SoundManager",
+    "BioFeedbackOverlay",
 ]

--- a/calmio/biofeedback.json
+++ b/calmio/biofeedback.json
@@ -1,0 +1,25 @@
+{
+  "messages": [
+    {"id": 1, "mensaje": "Tu ritmo cardíaco bajó naturalmente.", "tipo": "biofeedback_real"},
+    {"id": 2, "mensaje": "Se redujo tu nivel de cortisol.", "tipo": "biofeedback_real"},
+    {"id": 3, "mensaje": "Mayor flujo de ondas alfa cerebrales.", "tipo": "biofeedback_real"},
+    {"id": 4, "mensaje": "Activaste tu sistema parasimpático.", "tipo": "biofeedback_real"},
+    {"id": 5, "mensaje": "Tu atención se volvió más sostenida.", "tipo": "biofeedback_real"},
+    {"id": 6, "mensaje": "Mejoró tu regulación emocional.", "tipo": "biofeedback_real"},
+    {"id": 7, "mensaje": "Estimulaste el nervio vago.", "tipo": "biofeedback_real"},
+    {"id": 8, "mensaje": "Tu presión arterial disminuyó.", "tipo": "biofeedback_real"},
+    {"id": 9, "mensaje": "Se sincronizó tu respiración con tu corazón.", "tipo": "biofeedback_real"},
+    {"id": 10, "mensaje": "Tu sistema límbico se estabilizó.", "tipo": "biofeedback_real"},
+
+    {"id": 11, "mensaje": "Tu mente se calmó un 34%.", "tipo": "biofeedback_falso"},
+    {"id": 12, "mensaje": "Tu respiración fue 81% fluida.", "tipo": "biofeedback_falso"},
+    {"id": 13, "mensaje": "Nivel de enfoque: 4 estrellas ✨✨✨✨", "tipo": "biofeedback_falso"},
+    {"id": 14, "mensaje": "Reducción de caos mental: -16 unidades.", "tipo": "biofeedback_falso"},
+    {"id": 15, "mensaje": "Claridad mental al 88%.", "tipo": "biofeedback_falso"},
+    {"id": 16, "mensaje": "Despertaste el modo zen.", "tipo": "biofeedback_falso"},
+    {"id": 17, "mensaje": "Nivel de presencia: 73%.", "tipo": "biofeedback_falso"},
+    {"id": 18, "mensaje": "Redujiste la turbulencia emocional un 41%.", "tipo": "biofeedback_falso"},
+    {"id": 19, "mensaje": "Conciencia expandida en un 69%.", "tipo": "biofeedback_falso"},
+    {"id": 20, "mensaje": "Frecuencia interior armonizada.", "tipo": "biofeedback_falso"}
+  ]
+}

--- a/calmio/biofeedback_overlay.py
+++ b/calmio/biofeedback_overlay.py
@@ -1,0 +1,57 @@
+from PySide6.QtCore import Qt, Signal, QPropertyAnimation, QSequentialAnimationGroup
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QGraphicsOpacityEffect
+
+
+class BioFeedbackOverlay(QWidget):
+    """Simple overlay to display a biofeedback message with fade in/out."""
+
+    done = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setStyleSheet("background-color:white;color:#222;")
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.addStretch()
+
+        self.label = QLabel("", self)
+        font = QFont("Sans Serif")
+        font.setPointSize(20)
+        font.setWeight(QFont.Bold)
+        self.label.setFont(font)
+        self.label.setAlignment(Qt.AlignCenter)
+
+        self.opacity = QGraphicsOpacityEffect(self.label)
+        self.label.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(0)
+
+        layout.addWidget(self.label, alignment=Qt.AlignCenter)
+        layout.addStretch()
+
+        self.anim = None
+
+    def show_message(self, text: str):
+        self.label.setText(text)
+        self.opacity.setOpacity(0)
+        self.show()
+        fade_in = QPropertyAnimation(self.opacity, b"opacity", self)
+        fade_in.setDuration(1000)
+        fade_in.setStartValue(0)
+        fade_in.setEndValue(1)
+        fade_out = QPropertyAnimation(self.opacity, b"opacity", self)
+        fade_out.setDuration(2000)
+        fade_out.setStartValue(1)
+        fade_out.setEndValue(0)
+        group = QSequentialAnimationGroup(self)
+        group.addAnimation(fade_in)
+        group.addPause(1500)
+        group.addAnimation(fade_out)
+        group.finished.connect(self._on_done)
+        group.start()
+        self.anim = group
+
+    def _on_done(self):
+        self.hide()
+        self.done.emit()

--- a/calmio/session_manager.py
+++ b/calmio/session_manager.py
@@ -168,7 +168,6 @@ class SessionManager:
             self.window.session_complete.show_badges(new_badges)
         else:
             self.window.session_complete.show_badges([])
-        self.window.stack.setCurrentWidget(self.window.session_complete)
         self.window.stats_overlay.update_streak(self.window.data_store.get_streak())
         self.window.stats_overlay.update_badges(
             self.window.data_store.get_badges_for_date(self.window.data_store.now())
@@ -184,6 +183,8 @@ class SessionManager:
         self.window.bg_anim.setEndValue(0.0)
         self.window.bg_anim.setEasingCurve(QEasingCurve.InOutSine)
         self.window.bg_anim.start()
+
+        self.window.show_biofeedback_message()
 
     def toggle_developer_speed(self):
         self.window.speed_multiplier = 10 if getattr(self.window, "speed_multiplier", 1) == 1 else 1


### PR DESCRIPTION
## Summary
- create `biofeedback_overlay` for final session message
- add `biofeedback.json` with real and fictional metrics
- load and show random biofeedback at session end
- update init exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684674f145b8832ba89e7ace95023f26