### PR TITLE
Add random motivational message logic

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -325,7 +325,6 @@ class MainWindow(QMainWindow):
 
     def update_count(self, count):
         """Handle breath count updates after a full cycle."""
-        self.check_motivational_message(count)
         if hasattr(self, "sound_manager"):
             play_music = True
             if self.current_pattern_id == "triple":

--- a/calmio/motivational_messages.json
+++ b/calmio/motivational_messages.json
@@ -7,6 +7,21 @@
     "Est\u00e1s haciendo un gran trabajo",
     "Suelta las distracciones y vuelve a tu respiraci\u00f3n",
     "Encuentra quietud en este momento",
-    "Tu mente se aclara con cada inhalaci\u00f3n"
+    "Tu mente se aclara con cada inhalaci\u00f3n",
+    "Vuelve a ti.",
+    "Respira en presencia.",
+    "Todo est\u00e1 bien.",
+    "No hay apuro.",
+    "Aqu\u00ed y ahora.",
+    "Observa sin juicio.",
+    "Cada exhalaci\u00f3n, una entrega.",
+    "Calma en el centro del caos.",
+    "Nada que alcanzar.",
+    "Suelta lo que pesa.",
+    "El silencio tambi\u00e9n habla.",
+    "Todo cambia. Y est\u00e1 bien.",
+    "Est\u00e1s respirando. Est\u00e1s vivo.",
+    "Tu atenci\u00f3n es tu poder.",
+    "Donde est\u00e1 tu atenci\u00f3n, est\u00e1 tu vida."
   ]
 }

--- a/calmio/session_manager.py
+++ b/calmio/session_manager.py
@@ -14,6 +14,7 @@ class SessionManager:
             self.window.meditation_seconds += 1
             self.window.session_seconds += 1
             self.window.stats_overlay.update_minutes(self.window.meditation_seconds)
+            self.window.check_motivational_message(self.window.session_seconds)
 
     def start_waves(self, center, color):
         if hasattr(self.window, "wave_overlay"):
@@ -29,6 +30,7 @@ class SessionManager:
             self.window._chakra_index = 0
             if hasattr(self.window, "bg"):
                 self.window.bg.transition_to_index(0, duration=0)
+            self.window.message_handler.start_session()
         self.window.cycle_start = time.perf_counter()
 
         if (
@@ -139,6 +141,7 @@ class SessionManager:
         if not self.window.session_active:
             return
         self.window.session_active = False
+        self.window.message_handler.end_session()
         start_str = self.window.session_start.strftime("%H:%M:%S") if self.window.session_start else ""
         duration_seconds = self.window.session_seconds
         breaths = self.window.circle.breath_count


### PR DESCRIPTION
## Summary
- expand motivational message list
- randomize message display timing and enforce 30 second cooldown
- start/stop message timer with session
- check for message display every second

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684682e86988832b98f008bbc81b8bf5