### PR TITLE
Add dark mode preference

### DIFF
--- a/calmio/animated_background.py
+++ b/calmio/animated_background.py
@@ -105,6 +105,17 @@ class AnimatedBackground(QWidget):
             base = [c.darker(180) for c in base]
         return [self._saturate(c) for c in base]
 
+    def set_dark_mode(self, value: bool) -> None:
+        """Update dark mode setting and refresh colors."""
+        if self.dark_mode == bool(value):
+            return
+        self.dark_mode = bool(value)
+        self._colors = self._chakra_colors()
+        current = self._colors[self._chakra_index]
+        self.set_color1(current)
+        base2 = current.lighter(150) if not self.dark_mode else current.darker(150)
+        self.set_color2(self._saturate(base2))
+
     def chakra_colors(self):
         """Return the list of chakra colors."""
         return list(self._colors)

--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -21,6 +21,9 @@ class DataStore:
             "badges": {},
             # badges earned today {date: {code: count}}
             "daily_badges": {},
+            "visual_settings": {
+                "dark_mode": False,
+            },
             "sound_settings": {
                 "music_enabled": False,
                 "bell_enabled": False,
@@ -71,6 +74,8 @@ class DataStore:
                                 for b in v:
                                     counts[b] = counts.get(b, 0) + 1
                                 self.data["daily_badges"][k] = counts
+                    if "visual_settings" not in self.data:
+                        self.data["visual_settings"] = {"dark_mode": False}
                     if "sound_settings" not in self.data:
                         self.data["sound_settings"] = {
                             "music_enabled": False,
@@ -89,6 +94,14 @@ class DataStore:
     def save(self):
         with self.path.open("w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2)
+
+    # ------------------------------------------------------------------
+    def get_visual_setting(self, name: str, default=None):
+        return self.data.get("visual_settings", {}).get(name, default)
+
+    def set_visual_setting(self, name: str, value) -> None:
+        self.data.setdefault("visual_settings", {})[name] = value
+        self.save()
 
     # ------------------------------------------------------------------
     def get_sound_setting(self, name: str, default=None):
@@ -352,11 +365,15 @@ class DataStore:
             "sessions": [],
             "badges": {},
             "daily_badges": {},
+            "visual_settings": {
+                "dark_mode": False,
+            },
             "sound_settings": {
                 "music_enabled": False,
                 "bell_enabled": False,
                 "music_mode": "scale",
                 "scale_type": "major",
+                "breath_volume": False,
             },
         }
         self.save()

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -52,17 +52,19 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Calmio")
         self.resize(360, 640)
 
+        self.data_store = DataStore()
         palette = QApplication.instance().palette()
-        dark_mode = palette.color(QPalette.Window).value() < 128
+        default_dark = palette.color(QPalette.Window).value() < 128
+        dark_mode = self.data_store.get_visual_setting("dark_mode", default_dark)
         self.bg = AnimatedBackground(self, dark_mode=dark_mode)
+        if self.data_store.get_visual_setting("dark_mode") is None:
+            self.data_store.set_visual_setting("dark_mode", dark_mode)
         self.bg.set_opacity(0.0)
         self.bg.lower()
         self.bg.setGeometry(self.rect())
         self.wave_overlay = WaveOverlay(self)
         self.wave_overlay.setGeometry(self.rect())
         self.wave_overlay.lower()
-
-        self.data_store = DataStore()
 
         self.session_active = False
         self.session_start = None

--- a/calmio/options_overlay.py
+++ b/calmio/options_overlay.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QPushButton,
     QMessageBox,
+    QCheckBox,
 )
 
 
@@ -42,6 +43,14 @@ class OptionsOverlay(QWidget):
         header.addStretch()
         layout.addLayout(header)
 
+        self.dark_chk = QCheckBox("Modo oscuro")
+        self.dark_chk.setStyleSheet("font-size:14px;")
+        store = getattr(parent, "data_store", None)
+        if store:
+            self.dark_chk.setChecked(store.get_visual_setting("dark_mode", False))
+        self.dark_chk.stateChanged.connect(self._dark_mode_changed)
+        layout.addWidget(self.dark_chk, alignment=Qt.AlignLeft)
+
         self.reset_btn = QPushButton("Borrar todos los datos")
         self.reset_btn.setStyleSheet(
             "QPushButton{" "background-color:#CCE4FF;border:none;border-radius:20px;"
@@ -51,6 +60,15 @@ class OptionsOverlay(QWidget):
         layout.addWidget(self.reset_btn, alignment=Qt.AlignCenter)
 
         layout.addStretch()
+
+    def _dark_mode_changed(self, state: int) -> None:
+        is_dark = state == Qt.Checked
+        parent = self.parent()
+        store = getattr(parent, "data_store", None)
+        if store:
+            store.set_visual_setting("dark_mode", is_dark)
+        if hasattr(parent, "bg"):
+            parent.bg.set_dark_mode(is_dark)
 
     def confirm_reset(self):
         reply = QMessageBox.question(

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -69,3 +69,16 @@ def test_breath_volume_setting(tmp_path):
     # ensure persistence
     ds2 = DataStore(data_file)
     assert ds2.get_sound_setting("breath_volume") is True
+
+
+def test_dark_mode_setting(tmp_path):
+    data_file = tmp_path / "data.json"
+    ds = DataStore(data_file)
+
+    assert ds.get_visual_setting("dark_mode", False) is False
+
+    ds.set_visual_setting("dark_mode", True)
+    assert ds.get_visual_setting("dark_mode") is True
+
+    ds2 = DataStore(data_file)
+    assert ds2.get_visual_setting("dark_mode") is True


### PR DESCRIPTION
## Summary
- add visual_settings storage with dark_mode flag in DataStore
- expose get_visual_setting/set_visual_setting
- add dark mode checkbox to OptionsOverlay
- allow AnimatedBackground to update colors when dark mode changes
- load stored dark mode in MainWindow
- test persistence of dark mode setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684733ff82cc832b94e0b6ede4754fbe