### PR TITLE
Integrate achievement catalog

### DIFF
--- a/calmio/achievements.py
+++ b/calmio/achievements.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+# Load achievements catalog from JSON at import time
+CATALOG_PATH = Path(__file__).resolve().parents[1] / "logros_meditacion_100.json"
+with CATALOG_PATH.open("r", encoding="utf-8") as f:
+    _CATALOG = json.load(f)
+
+# Dictionary indexed by achievement id for quick lookup
+ACHIEVEMENTS = {item["id"]: item for item in _CATALOG}
+
+# Map legacy badge codes used internally to ids in the catalog
+BADGE_MAP = {
+    "1_breath_session": 1,
+    "5_breaths_session": 2,
+    "10_breaths": 3,
+    "20_breaths_session": 4,
+    "30_breaths_session": 5,
+    "40_breaths_session": 6,
+    "50_breaths_session": 7,
+    "60_breaths_session": 8,
+    "80_breaths_session": 9,
+    "100_breaths_session": 30,
+    "1_session_day": 10,
+    "2_sessions_day": 27,
+    "3_sessions_day": 28,
+    "5_min_total": 3,
+    "3_day_streak": 21,
+    "7_day_streak": 22,
+    "30_day_streak": 23,
+}
+
+
+def get_badge_info(code_or_id):
+    """Return catalog entry for the given code or id."""
+    if isinstance(code_or_id, str):
+        badge_id = BADGE_MAP.get(code_or_id)
+    else:
+        badge_id = code_or_id
+    return ACHIEVEMENTS.get(badge_id, {"nombre": str(code_or_id), "emoji": ""})

--- a/calmio/badges_view.py
+++ b/calmio/badges_view.py
@@ -83,7 +83,7 @@ class BadgesView(QWidget):
     ]
 
     def set_badges(self, badges):
-        from .badges import BADGE_NAMES
+        from .achievements import get_badge_info
 
         for i in reversed(range(self.list_layout.count() - 1)):
             item = self.list_layout.takeAt(i)
@@ -112,7 +112,8 @@ class BadgesView(QWidget):
             row.setContentsMargins(6, 2, 6, 2)
             level = min(count, len(self.LEVEL_EMOJIS))
             medal = self.LEVEL_EMOJIS[level - 1]
-            text = QLabel(f"{BADGE_NAMES.get(code, code)} - Nivel {level}")
+            info = get_badge_info(code)
+            text = QLabel(f"{info.get('emoji', '')} {info.get('nombre', code)} - Nivel {level}")
             txt_font = QFont("Sans Serif")
             txt_font.setBold(True)
             text.setFont(txt_font)

--- a/calmio/data_store.py
+++ b/calmio/data_store.py
@@ -136,7 +136,12 @@ class DataStore:
             }
         )
         new_badges = self._check_badges(start_dt, seconds, breaths)
-        daily_only = {
+        try:
+            from .achievements import BADGE_MAP
+        except ImportError:  # fallback when imported as standalone
+            from achievements import BADGE_MAP
+
+        daily_only_codes = {
             "1_session_day",
             "2_sessions_day",
             "3_sessions_day",
@@ -144,6 +149,7 @@ class DataStore:
             "7_day_streak",
             "30_day_streak",
         }
+        daily_only = {BADGE_MAP.get(c, c) for c in daily_only_codes}
         session_badges = [b for b in new_badges if b not in daily_only]
         # store only session-related badges with the session
         self.data["sessions"][-1]["badges"] = list(session_badges)
@@ -206,6 +212,11 @@ class DataStore:
 
     def _check_badges(self, start_dt, session_seconds, breaths):
         """Check and award badges based on totals, session data and streak."""
+        try:
+            from .achievements import BADGE_MAP
+        except ImportError:
+            from achievements import BADGE_MAP
+
         new_badges = []
 
         # total meditation time badges
@@ -252,7 +263,8 @@ class DataStore:
         if self.data.get("streak", 1) >= 30 and "30_day_streak" not in self.data["badges"]:
             new_badges.append("30_day_streak")
 
-        return new_badges
+        # Convert internal codes to catalog ids
+        return [BADGE_MAP.get(b, b) for b in new_badges]
 
     def get_weekly_summary(self, reference_date=None):
         """Return stats for the week of the given date (default today)."""

--- a/calmio/session_complete.py
+++ b/calmio/session_complete.py
@@ -136,10 +136,11 @@ class SessionComplete(QWidget):
         self.end_lbl.setText(f"\u23F0 Fin: {end}")
 
     def show_badges(self, badges):
-        from .badges import BADGE_NAMES
+        from .achievements import get_badge_info
         self._badges = list(badges)
         if badges:
-            name = BADGE_NAMES.get(badges[-1], badges[-1])
+            info = get_badge_info(badges[-1])
+            name = info.get("nombre", badges[-1])
             self.badge_btn.setText("\u2728 " + name)
             self.badge_btn.show()
         else:

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -82,3 +82,26 @@ def test_dark_mode_setting(tmp_path):
 
     ds2 = DataStore(data_file)
     assert ds2.get_visual_setting("dark_mode") is True
+
+from datetime import timedelta
+from achievements import BADGE_MAP
+
+
+def test_badge_awarded_and_lookup(tmp_path):
+    data_file = tmp_path / "data.json"
+    ds = DataStore(data_file)
+    start = datetime(2023, 1, 1, 8, 0)
+    ds.add_session(start, seconds=300, breaths=10, inhale=3, exhale=3)
+    badges = ds.get_badges_for_date(start)
+    assert BADGE_MAP["5_min_total"] in badges
+    assert BADGE_MAP["1_breath_session"] in badges
+
+
+def test_three_day_streak_badge(tmp_path):
+    data_file = tmp_path / "data.json"
+    ds = DataStore(data_file)
+    start = datetime(2023, 1, 1, 8, 0)
+    for i in range(3):
+        ds.add_session(start + timedelta(days=i), seconds=60, breaths=1, inhale=3, exhale=3)
+    third_day_badges = ds.get_badges_for_date(start + timedelta(days=2))
+    assert BADGE_MAP["3_day_streak"] in third_day_badges


### PR DESCRIPTION
## Summary
- load logros_meditacion_100.json as achievements catalog
- map existing badge codes to catalog IDs and use them in `DataStore`
- show badge emoji and name from catalog in `BadgesView` and session completion
- add tests for badge awarding

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684738cca2ac832b95f9a654f2e35c1f