### PR TITLE
Implement glass-style main menu modal

### DIFF
--- a/calmio/main_menu_overlay.py
+++ b/calmio/main_menu_overlay.py
@@ -1,0 +1,123 @@
+from PySide6.QtCore import Qt, Signal, QPropertyAnimation
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QGridLayout,
+    QLabel,
+    QPushButton,
+    QGraphicsOpacityEffect,
+    QGraphicsDropShadowEffect,
+)
+from PySide6.QtGui import QFont
+
+
+class MainMenuOverlay(QWidget):
+    """Central modal menu with glassmorphism style."""
+
+    music_requested = Signal()
+    breathing_requested = Signal()
+    mantras_requested = Signal()
+    achievements_requested = Signal()
+    settings_requested = Signal()
+    closed = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setStyleSheet(
+            "background-color: rgba(255, 255, 255, 180);"
+            "border-radius:24px;"
+            "color:#222;"
+        )
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(20)
+        shadow.setOffset(0, 4)
+        self.setGraphicsEffect(shadow)
+
+        self.opacity = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(0)
+
+        layout = QGridLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(20)
+
+        self.music_btn = self._create_btn("\U0001F3B5", "M\u00fasica")
+        self.breath_btn = self._create_btn("\U0001FAC1", "Respiraci\u00f3n")
+        self.mantras_btn = self._create_btn("\u2764\ufe0f", "Mantras")
+        self.ach_btn = self._create_btn("\U0001F9E0", "Logros")
+        self.settings_btn = self._create_btn("\u2699\ufe0f", "Ajustes")
+        self.close_btn = self._create_btn("\U0001F534", "Cerrar")
+
+        layout.addWidget(self.music_btn, 0, 0)
+        layout.addWidget(self.breath_btn, 0, 1)
+        layout.addWidget(self.mantras_btn, 1, 0)
+        layout.addWidget(self.ach_btn, 1, 1)
+        layout.addWidget(self.settings_btn, 2, 0)
+        layout.addWidget(self.close_btn, 2, 1)
+
+        self.music_btn.clicked.connect(self.music_requested.emit)
+        self.breath_btn.clicked.connect(self.breathing_requested.emit)
+        self.mantras_btn.clicked.connect(self.mantras_requested.emit)
+        self.ach_btn.clicked.connect(self.achievements_requested.emit)
+        self.settings_btn.clicked.connect(self.settings_requested.emit)
+        self.close_btn.clicked.connect(self.close)
+
+        self.anim = None
+
+    def _create_btn(self, icon: str, text: str) -> QPushButton:
+        btn = QPushButton()
+        btn.setCursor(Qt.PointingHandCursor)
+        btn.setStyleSheet(
+            "QPushButton{"
+            "background: rgba(255,255,255,200);"
+            "border:none;border-radius:20px;"
+            "padding:10px;"
+            "}"
+            "QPushButton:hover{background: rgba(255,255,255,230);}"
+        )
+        vbox = QVBoxLayout(btn)
+        vbox.setContentsMargins(5, 5, 5, 5)
+        icon_lbl = QLabel(icon)
+        icon_font = QFont("Sans Serif")
+        icon_font.setPointSize(24)
+        icon_lbl.setFont(icon_font)
+        icon_lbl.setAlignment(Qt.AlignCenter)
+        text_lbl = QLabel(text)
+        text_font = QFont("Sans Serif")
+        text_font.setPointSize(16)
+        text_lbl.setFont(text_font)
+        text_lbl.setAlignment(Qt.AlignCenter)
+        vbox.addWidget(icon_lbl)
+        vbox.addWidget(text_lbl)
+        return btn
+
+    def open(self):
+        parent = self.parent() or self
+        w = int(parent.width() * 0.8)
+        h = int(parent.height() * 0.6)
+        x = (parent.width() - w) // 2
+        y = (parent.height() - h) // 2
+        self.setGeometry(x, y, w, h)
+        self.show()
+        self.raise_()
+        self._animate(True)
+
+    def close(self):
+        self._animate(False)
+
+    def _animate(self, opening: bool):
+        if self.anim:
+            self.anim.stop()
+        anim = QPropertyAnimation(self.opacity, b"opacity", self)
+        anim.setDuration(250)
+        if opening:
+            anim.setStartValue(0)
+            anim.setEndValue(1)
+        else:
+            anim.setStartValue(self.opacity.opacity())
+            anim.setEndValue(0)
+            anim.finished.connect(super().hide)
+            anim.finished.connect(self.closed.emit)
+        anim.start()
+        self.anim = anim

--- a/calmio/mantras_overlay.py
+++ b/calmio/mantras_overlay.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QHBoxLayout,
+    QListWidget,
+    QInputDialog,
+)
+from PySide6.QtGui import QFont
+import json
+from pathlib import Path
+
+
+class MantrasOverlay(QWidget):
+    """Overlay to view and edit motivational messages."""
+
+    back_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setStyleSheet(
+            "background-color:#FAFAFA;border-radius:20px;color:#444;"
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(15)
+
+        header = QHBoxLayout()
+        self.back_btn = QPushButton("\u2190")
+        self.back_btn.setStyleSheet(
+            "QPushButton{background:none;border:none;font-size:18px;}"
+        )
+        self.back_btn.clicked.connect(self.back_requested.emit)
+        header.addWidget(self.back_btn, alignment=Qt.AlignLeft)
+
+        title = QLabel("Mantras")
+        t_font = QFont("Sans Serif")
+        t_font.setPointSize(20)
+        t_font.setWeight(QFont.Medium)
+        title.setFont(t_font)
+        title.setAlignment(Qt.AlignCenter)
+        header.addWidget(title, alignment=Qt.AlignCenter)
+        header.addStretch()
+        layout.addLayout(header)
+
+        self.list_widget = QListWidget()
+        layout.addWidget(self.list_widget)
+
+        btn_row = QHBoxLayout()
+        self.add_btn = QPushButton("Agregar")
+        self.del_btn = QPushButton("Eliminar")
+        self.add_btn.clicked.connect(self._add_message)
+        self.del_btn.clicked.connect(self._del_message)
+        btn_row.addWidget(self.add_btn)
+        btn_row.addWidget(self.del_btn)
+        btn_row.addStretch()
+        layout.addLayout(btn_row)
+
+        self._load_messages()
+
+    # -------------------------------------------------------------
+    def _messages_file(self) -> Path:
+        return Path(__file__).resolve().parent / "motivational_messages.json"
+
+    def _load_messages(self):
+        handler = getattr(self.parent(), "message_handler", None)
+        msgs = []
+        if handler:
+            msgs = handler.motivational_messages
+        if not msgs:
+            try:
+                data = json.loads(self._messages_file().read_text(encoding="utf-8"))
+                msgs = data.get("messages", [])
+            except Exception:
+                msgs = []
+        for m in msgs:
+            self.list_widget.addItem(m)
+
+    def _save_messages(self):
+        handler = getattr(self.parent(), "message_handler", None)
+        msgs = [self.list_widget.item(i).text() for i in range(self.list_widget.count())]
+        if handler:
+            handler.motivational_messages = msgs
+        try:
+            with self._messages_file().open("w", encoding="utf-8") as f:
+                json.dump({"messages": msgs}, f, ensure_ascii=False, indent=2)
+        except Exception:
+            pass
+
+    def _add_message(self):
+        text, ok = QInputDialog.getText(self, "Nuevo mantra", "Texto:")
+        if ok and text.strip():
+            self.list_widget.addItem(text.strip())
+            self._save_messages()
+
+    def _del_message(self):
+        row = self.list_widget.currentRow()
+        if row >= 0:
+            self.list_widget.takeItem(row)
+            self._save_messages()

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -51,11 +51,14 @@ class MenuHandler:
 
     # --- visibility toggles --------------------------------------------
     def toggle_menu(self) -> None:
-        if self.window.options_button.isVisible():
-            self.hide_control_buttons()
-            self.window.dev_menu.hide()
+        """Show or hide the glass style main menu."""
+        if self.window.main_menu_overlay.isVisible():
+            self.close_main_menu()
         else:
-            self.show_control_buttons()
+            self.window.main_menu_overlay.open()
+
+    def close_main_menu(self) -> None:
+        self.window.main_menu_overlay.close()
 
     def toggle_options(self) -> None:
         if self.window.options_overlay.isVisible():
@@ -96,6 +99,17 @@ class MenuHandler:
     def close_breath_modes(self) -> None:
         self.window.breath_modes.hide()
         self.hide_control_buttons()
+
+    def toggle_mantras(self) -> None:
+        if self.window.mantras_overlay.isVisible():
+            self.close_mantras()
+        else:
+            self.window.mantras_overlay.show()
+            self.window.mantras_overlay.raise_()
+
+    def close_mantras(self) -> None:
+        self.window.mantras_overlay.hide()
+
 
     def hide_control_buttons(self) -> None:
         for btn in self.window.control_buttons:


### PR DESCRIPTION
## Summary
- add new `MainMenuOverlay` with glassmorphism style
- create `MantrasOverlay` for editing floating messages
- update `MenuHandler` to control new overlays
- integrate overlays in `MainWindow` and adjust resize/click handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684749503498832ba8a07c4468562c5f