### PR TITLE
Modern modal menu

### DIFF
--- a/calmio/main_menu_overlay.py
+++ b/calmio/main_menu_overlay.py
@@ -3,9 +3,9 @@ from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QGridLayout,
+    QHBoxLayout,
     QLabel,
     QPushButton,
-    QGraphicsOpacityEffect,
     QGraphicsDropShadowEffect,
 )
 from PySide6.QtGui import QFont
@@ -34,14 +34,27 @@ class MainMenuOverlay(QWidget):
         shadow.setOffset(0, 4)
         self.setGraphicsEffect(shadow)
 
-        self.opacity = QGraphicsOpacityEffect(self)
-        self.setGraphicsEffect(self.opacity)
-        self.opacity.setOpacity(0)
+        self.setWindowOpacity(0)
 
-        layout = QGridLayout(self)
+        layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(20)
 
+        header = QHBoxLayout()
+        self.dismiss_btn = QPushButton("\u274C")
+        self.dismiss_btn.setFixedSize(24, 24)
+        self.dismiss_btn.setStyleSheet(
+            "QPushButton{background:none;border:none;font-size:18px;}"
+        )
+        self.dismiss_btn.setCursor(Qt.PointingHandCursor)
+        self.dismiss_btn.clicked.connect(self.close)
+        header.addWidget(self.dismiss_btn, alignment=Qt.AlignLeft)
+        header.addStretch()
+        layout.addLayout(header)
+
+        grid = QGridLayout()
+        grid.setSpacing(20)
+        
         self.music_btn = self._create_btn("\U0001F3B5", "M\u00fasica")
         self.breath_btn = self._create_btn("\U0001FAC1", "Respiraci\u00f3n")
         self.mantras_btn = self._create_btn("\u2764\ufe0f", "Mantras")
@@ -49,12 +62,16 @@ class MainMenuOverlay(QWidget):
         self.settings_btn = self._create_btn("\u2699\ufe0f", "Ajustes")
         self.close_btn = self._create_btn("\U0001F534", "Cerrar")
 
-        layout.addWidget(self.music_btn, 0, 0)
-        layout.addWidget(self.breath_btn, 0, 1)
-        layout.addWidget(self.mantras_btn, 1, 0)
-        layout.addWidget(self.ach_btn, 1, 1)
-        layout.addWidget(self.settings_btn, 2, 0)
-        layout.addWidget(self.close_btn, 2, 1)
+        grid.addWidget(self.music_btn, 0, 0)
+        grid.addWidget(self.breath_btn, 0, 1)
+        grid.addWidget(self.mantras_btn, 1, 0)
+        grid.addWidget(self.ach_btn, 1, 1)
+        grid.addWidget(self.settings_btn, 2, 0)
+        grid.addWidget(self.close_btn, 2, 1)
+
+        layout.addLayout(grid)
+
+        layout.addStretch()
 
         self.music_btn.clicked.connect(self.music_requested.emit)
         self.breath_btn.clicked.connect(self.breathing_requested.emit)
@@ -109,13 +126,13 @@ class MainMenuOverlay(QWidget):
     def _animate(self, opening: bool):
         if self.anim:
             self.anim.stop()
-        anim = QPropertyAnimation(self.opacity, b"opacity", self)
+        anim = QPropertyAnimation(self, b"windowOpacity", self)
         anim.setDuration(250)
         if opening:
             anim.setStartValue(0)
             anim.setEndValue(1)
         else:
-            anim.setStartValue(self.opacity.opacity())
+            anim.setStartValue(self.windowOpacity())
             anim.setEndValue(0)
             anim.finished.connect(super().hide)
             anim.finished.connect(self.closed.emit)

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -32,7 +32,6 @@ from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .badges_view import BadgesView
 from .options_overlay import OptionsOverlay
-from .developer_overlay import DeveloperOverlay
 from .sound_overlay import SoundOverlay
 from .breath_modes_overlay import BreathModesOverlay
 from .main_menu_overlay import MainMenuOverlay
@@ -187,32 +186,13 @@ class MainWindow(QMainWindow):
 
         self.setFocus()
 
-        self.options_button = QPushButton("\u2699\ufe0f", self)
-        self.stats_button = QPushButton("\ud83d\udcca", self)
-        self.end_button = QPushButton("\U0001F6D1", self)
-        self.dev_button = QPushButton("\U0001F41B", self)
-        self.sound_button = QPushButton("\U0001F3B5", self)
-        self.patterns_button = QPushButton("\U0001FAC2", self)
-
-        self.control_buttons = [
-            self.options_button,
-            self.stats_button,
-            self.end_button,
-            self.dev_button,
-            self.sound_button,
-            self.patterns_button,
-        ]
-        for btn in self.control_buttons:
-            self._setup_control_button(btn)
-
-        self.end_button.clicked.connect(self.session_manager.end_session)
+        self.control_buttons = []
 
         self.menu_button.setFocusPolicy(Qt.NoFocus)
 
         self.stats_overlay = StatsOverlay(self)
         self.stats_overlay.setGeometry(self.rect())
         self.stats_overlay.hide()
-        self.stats_button.clicked.connect(self.overlay_manager.toggle_stats)
         self.stats_overlay.view_sessions.connect(self.overlay_manager.open_today_sessions)
         self.stats_overlay.session_requested.connect(self.overlay_manager.open_session_details)
         self.stats_overlay.view_badges_today.connect(self.overlay_manager.open_today_badges)
@@ -239,12 +219,7 @@ class MainWindow(QMainWindow):
         self.options_overlay.setGeometry(self.rect())
         self.options_overlay.hide()
         self.options_overlay.back_requested.connect(self.menu_handler.close_options)
-        self.options_button.clicked.connect(self.menu_handler.toggle_options)
-        self.dev_menu = DeveloperOverlay(self)
-        self.dev_menu.hide()
-        self.dev_menu.speed_toggled.connect(self.session_manager.toggle_developer_speed)
-        self.dev_menu.next_day_requested.connect(self.session_manager.advance_day)
-        self.dev_button.clicked.connect(self.menu_handler.toggle_developer_menu)
+
 
         self.sound_overlay = SoundOverlay(self)
         self.sound_overlay.setGeometry(self.rect())
@@ -261,14 +236,12 @@ class MainWindow(QMainWindow):
         self.sound_overlay.music_mode_changed.connect(self.sound_manager.set_music_mode)
         self.sound_overlay.scale_changed.connect(self.sound_manager.set_scale_type)
         self.sound_overlay.breath_volume_toggled.connect(self.sound_manager.set_breath_volume_enabled)
-        self.sound_button.clicked.connect(self.menu_handler.toggle_sound)
 
         self.breath_modes = BreathModesOverlay(self)
         self.breath_modes.setGeometry(self.rect())
         self.breath_modes.hide()
         self.breath_modes.back_requested.connect(self.menu_handler.close_breath_modes)
         self.breath_modes.pattern_selected.connect(self._on_pattern_selected)
-        self.patterns_button.clicked.connect(self.menu_handler.toggle_breath_modes)
 
         self.mantras_overlay = MantrasOverlay(self)
         self.mantras_overlay.setGeometry(self.rect())
@@ -456,11 +429,6 @@ class MainWindow(QMainWindow):
                 pos = self.mapFromGlobal(event.globalPos())
             if not (
                 self.menu_button.geometry().contains(pos)
-                or self.options_button.geometry().contains(pos)
-                or self.stats_button.geometry().contains(pos)
-                or self.end_button.geometry().contains(pos)
-                or self.dev_button.geometry().contains(pos)
-                or self.dev_menu.geometry().contains(pos)
                 or self.stats_overlay.geometry().contains(pos)
                 or self.today_sessions.geometry().contains(pos)
                 or self.session_details.geometry().contains(pos)
@@ -477,7 +445,6 @@ class MainWindow(QMainWindow):
                 ):
                 self.menu_handler.close_main_menu()
                 self.menu_handler.close_mantras()
-                self.dev_menu.hide()
                 self.stats_overlay.hide()
                 self.today_sessions.hide()
                 self.session_details.hide()
@@ -508,11 +475,6 @@ class MainWindow(QMainWindow):
         pos = event.pos()
         if not (
             self.menu_button.geometry().contains(pos)
-            or self.options_button.geometry().contains(pos)
-            or self.stats_button.geometry().contains(pos)
-            or self.end_button.geometry().contains(pos)
-            or self.dev_button.geometry().contains(pos)
-            or self.dev_menu.geometry().contains(pos)
             or self.stats_overlay.geometry().contains(pos)
             or self.today_sessions.geometry().contains(pos)
             or self.session_details.geometry().contains(pos)
@@ -529,7 +491,6 @@ class MainWindow(QMainWindow):
         ):
             self.menu_handler.close_main_menu()
             self.menu_handler.close_mantras()
-            self.dev_menu.hide()
             self.stats_overlay.hide()
             self.today_sessions.hide()
             self.session_details.hide()

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -15,22 +15,10 @@ class MenuHandler:
         x = self.window.width() - self.window.menu_button.width() - margin
         y = self.window.height() - self.window.menu_button.height() - margin
         self.window.menu_button.move(x, y)
-        buttons = [
-            self.window.options_button,
-            self.window.stats_button,
-            self.window.end_button,
-            self.window.dev_button,
-        ]
-        if hasattr(self.window, "sound_button"):
-            buttons.append(self.window.sound_button)
-        if hasattr(self.window, "patterns_button"):
-            buttons.append(self.window.patterns_button)
-        for i, btn in enumerate(buttons, start=1):
-            btn.move(x - i * (self.window.menu_button.width() + margin), y)
         if hasattr(self.window, "dev_menu"):
             self.window.dev_menu.move(
-                self.window.dev_button.x() - self.window.dev_menu.width() + self.window.dev_button.width(),
-                self.window.dev_button.y() - self.window.dev_menu.height() - margin,
+                x - self.window.dev_menu.width() + self.window.menu_button.width(),
+                y - self.window.dev_menu.height() - margin,
             )
         self.window.stats_overlay.setGeometry(self.window.rect())
         self.window.today_sessions.setGeometry(self.window.rect())
@@ -72,11 +60,7 @@ class MenuHandler:
         self.hide_control_buttons()
 
     def toggle_developer_menu(self) -> None:
-        if self.window.dev_menu.isVisible():
-            self.window.dev_menu.hide()
-        else:
-            self.window.dev_menu.show()
-            self.window.dev_menu.raise_()
+        pass
 
     def toggle_sound(self) -> None:
         if self.window.sound_overlay.isVisible():

--- a/calmio/session_manager.py
+++ b/calmio/session_manager.py
@@ -182,7 +182,6 @@ class SessionManager:
             self.window.data_store.get_badges_for_date(self.window.data_store.now())
         )
         self.window.menu_handler.hide_control_buttons()
-        self.window.dev_menu.hide()
 
         if hasattr(self.window, "bg_anim") and self.window.bg_anim.state() != QAbstractAnimation.Stopped:
             self.window.bg_anim.stop()


### PR DESCRIPTION
## Summary
- add central glass-style menu overlay with dismiss button
- remove obsolete bottom control buttons
- clean up menu handler logic
- drop developer menu references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474d932d18832b979100ac7dcf541b