### PR TITLE
Fix menu overlay visibility

### DIFF
--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -43,6 +43,8 @@ class MenuHandler:
         if self.window.main_menu_overlay.isVisible():
             self.close_main_menu()
         else:
+            # Hide any legacy control buttons before showing the modal
+            self.hide_control_buttons()
             self.window.main_menu_overlay.open()
 
     def close_main_menu(self) -> None:


### PR DESCRIPTION
## Summary
- hide any leftover legacy menu buttons before showing the modal menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847514f5b3c832bb282be1af58a58ad