### PR TITLE
Remove old bottom menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ En Windows puede ejecutarse `run_app.bat`, el script creará un entorno virtual 
 
 ## Menú y controles
 
-- Botón de tres puntos abre o cierra los botones secundarios:
-  - Estadísticas (`📊`), Configuración (`⚙️`), Sonido (`🎵`), Modos de respiración (`🫁`), Finalizar sesión (`🛑`) y menú de desarrollador (`🐛`).
-  - Los botones se ocultan cuando se pulsa fuera de ellos o al cerrar overlays.
+- El botón de tres puntos abre un menú modal centrado con estilo de tarjeta translúcida.
+  Desde allí se accede a Estadísticas (`📊`), Configuración (`⚙️`), Sonido (`🎵`),
+  Modos de respiración (`🫁`), Finalizar sesión (`🛑`) y el menú de desarrollador (`🐛`).
 - Finalizar sesión cierra la respiración en curso y muestra la vista de **Finalización de sesión**.
 - El menú de configuración permite borrar todos los datos guardados.
 
@@ -157,7 +157,7 @@ El overlay de estadísticas (`stats_overlay.py`) muestra diferentes pestañas ge
 - `MainWindow` orquesta todos los widgets y controla el estado global de la sesión.
 - `DataStore` persiste la información en `calmio_data.json` dentro del directorio de usuario mediante `platformdirs`.
 - `SessionManager` separa la lógica de temporización y animaciones del círculo.
-- `MenuHandler` posiciona y muestra u oculta los botones de control.
+- `MenuHandler` posiciona el botón de menú y gestiona el overlay principal.
 - `OverlayManager` abre y cierra las vistas secundarias.
 - `MessageHandler` administra los mensajes motivacionales.
 - `SoundManager` reproduce ambientes, notas y campanas.

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -186,7 +186,6 @@ class MainWindow(QMainWindow):
 
         self.setFocus()
 
-        self.control_buttons = []
 
         self.menu_button.setFocusPolicy(Qt.NoFocus)
 
@@ -566,15 +565,6 @@ class MainWindow(QMainWindow):
 
     def update_speed(self):
         self.session_manager.update_speed()
-
-    def _setup_control_button(self, button: QPushButton) -> None:
-        self.menu_handler._setup_control_button(button)
-
-    def hide_control_buttons(self) -> None:
-        self.menu_handler.hide_control_buttons()
-
-    def show_control_buttons(self) -> None:
-        self.menu_handler.show_control_buttons()
 
     def toggle_breath_modes(self) -> None:
         self.menu_handler.toggle_breath_modes()

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -31,10 +31,7 @@ class MenuHandler:
             self.window.breath_modes.setGeometry(self.window.rect())
 
     def _setup_control_button(self, button: QPushButton) -> None:
-        """Apply common styling to control buttons."""
-        button.setFixedSize(40, 40)
-        button.setStyleSheet("QPushButton {background:none; border:none; font-size:20px;}")
-        button.setFocusPolicy(Qt.NoFocus)
+        """Deprecated: kept for backwards compatibility."""
         button.hide()
 
     # --- visibility toggles --------------------------------------------
@@ -43,8 +40,6 @@ class MenuHandler:
         if self.window.main_menu_overlay.isVisible():
             self.close_main_menu()
         else:
-            # Hide any legacy control buttons before showing the modal
-            self.hide_control_buttons()
             self.window.main_menu_overlay.open()
 
     def close_main_menu(self) -> None:
@@ -59,7 +54,6 @@ class MenuHandler:
 
     def close_options(self) -> None:
         self.window.options_overlay.hide()
-        self.hide_control_buttons()
 
     def toggle_developer_menu(self) -> None:
         pass
@@ -73,7 +67,6 @@ class MenuHandler:
 
     def close_sound(self) -> None:
         self.window.sound_overlay.hide()
-        self.hide_control_buttons()
 
     def toggle_breath_modes(self) -> None:
         if self.window.breath_modes.isVisible():
@@ -84,7 +77,6 @@ class MenuHandler:
 
     def close_breath_modes(self) -> None:
         self.window.breath_modes.hide()
-        self.hide_control_buttons()
 
     def toggle_mantras(self) -> None:
         if self.window.mantras_overlay.isVisible():
@@ -98,9 +90,9 @@ class MenuHandler:
 
 
     def hide_control_buttons(self) -> None:
-        for btn in self.window.control_buttons:
-            btn.hide()
+        """Legacy no-op for removed bottom menu."""
+        pass
 
     def show_control_buttons(self) -> None:
-        for btn in self.window.control_buttons:
-            btn.show()
+        """Legacy no-op for removed bottom menu."""
+        pass

--- a/calmio/overlay_manager.py
+++ b/calmio/overlay_manager.py
@@ -18,7 +18,6 @@ class OverlayManager:
 
     def close_stats(self):
         self.window.stats_overlay.hide()
-        self.window.menu_handler.hide_control_buttons()
 
     def open_today_sessions(self):
         sessions = self.window.data_store.get_sessions_for_date(self.window.data_store.now())
@@ -42,7 +41,6 @@ class OverlayManager:
         self.window.label.setText("")
         self.window.count_opacity.setOpacity(0)
         self.window.session_seconds = 0
-        self.window.menu_handler.hide_control_buttons()
         self.window.start_prompt_animation()
 
     def on_session_complete_closed(self):
@@ -51,7 +49,6 @@ class OverlayManager:
         self.window.label.setText("")
         self.window.count_opacity.setOpacity(0)
         self.window.session_seconds = 0
-        self.window.menu_handler.hide_control_buttons()
         self.window.start_prompt_animation()
 
     def open_session_details(self, session):

--- a/calmio/session_manager.py
+++ b/calmio/session_manager.py
@@ -181,7 +181,6 @@ class SessionManager:
         self.window.stats_overlay.update_badges(
             self.window.data_store.get_badges_for_date(self.window.data_store.now())
         )
-        self.window.menu_handler.hide_control_buttons()
 
         if hasattr(self.window, "bg_anim") and self.window.bg_anim.state() != QAbstractAnimation.Stopped:
             self.window.bg_anim.stop()


### PR DESCRIPTION
## Summary
- remove legacy bottom navigation logic
- adjust MenuHandler to no-op old helpers
- update README to document modal menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684754bb15a0832bb262fef630171e1b