### PR TITLE
Implement glass-like modal main menu

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -39,6 +39,7 @@ from .data_store import DataStore
 from .animated_background import AnimatedBackground
 from .wave_overlay import WaveOverlay
 from .menu_handler import MenuHandler
+from .menu_overlay import MenuOverlay
 from .session_manager import SessionManager
 from .overlay_manager import OverlayManager
 from .message_utils import MessageHandler
@@ -268,6 +269,17 @@ class MainWindow(QMainWindow):
         self.breath_modes.pattern_selected.connect(self._on_pattern_selected)
         self.patterns_button.clicked.connect(self.menu_handler.toggle_breath_modes)
 
+        self.menu_overlay = MenuOverlay(self)
+        self.menu_overlay.hide()
+        self.menu_overlay.breath_modes_requested.connect(self.menu_handler.toggle_breath_modes)
+        self.menu_overlay.sound_requested.connect(self.menu_handler.toggle_sound)
+        self.menu_overlay.stats_requested.connect(self.overlay_manager.toggle_stats)
+        self.menu_overlay.end_requested.connect(self.session_manager.end_session)
+        self.menu_overlay.achievements_requested.connect(self.overlay_manager.open_today_badges)
+        self.menu_overlay.settings_requested.connect(self.menu_handler.toggle_options)
+        self.menu_overlay.developer_requested.connect(self.menu_handler.toggle_developer_menu)
+        self.menu_overlay.close_requested.connect(self.menu_handler.hide_control_buttons)
+
         music_enabled = self.data_store.get_sound_setting("music_enabled", False)
         bell_enabled = self.data_store.get_sound_setting("bell_enabled", False)
         breath_volume = self.data_store.get_sound_setting("breath_volume", False)
@@ -432,6 +444,7 @@ class MainWindow(QMainWindow):
                 pos = self.mapFromGlobal(event.globalPos())
             if not (
                 self.menu_button.geometry().contains(pos)
+                or self.menu_overlay.geometry().contains(pos)
                 or self.options_button.geometry().contains(pos)
                 or self.stats_button.geometry().contains(pos)
                 or self.end_button.geometry().contains(pos)
@@ -481,6 +494,7 @@ class MainWindow(QMainWindow):
         pos = event.pos()
         if not (
             self.menu_button.geometry().contains(pos)
+            or self.menu_overlay.geometry().contains(pos)
             or self.options_button.geometry().contains(pos)
             or self.stats_button.geometry().contains(pos)
             or self.end_button.geometry().contains(pos)

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -32,6 +32,8 @@ class MenuHandler:
                 self.window.dev_button.x() - self.window.dev_menu.width() + self.window.dev_button.width(),
                 self.window.dev_button.y() - self.window.dev_menu.height() - margin,
             )
+        if hasattr(self.window, "menu_overlay"):
+            self.window.menu_overlay.adjust_position()
         self.window.stats_overlay.setGeometry(self.window.rect())
         self.window.today_sessions.setGeometry(self.window.rect())
         self.window.session_details.setGeometry(self.window.rect())
@@ -51,11 +53,11 @@ class MenuHandler:
 
     # --- visibility toggles --------------------------------------------
     def toggle_menu(self) -> None:
-        if self.window.options_button.isVisible():
-            self.hide_control_buttons()
+        if self.window.menu_overlay.isVisible():
+            self.window.menu_overlay.hide_with_anim()
             self.window.dev_menu.hide()
         else:
-            self.show_control_buttons()
+            self.window.menu_overlay.show_with_anim()
 
     def toggle_options(self) -> None:
         if self.window.options_overlay.isVisible():
@@ -63,10 +65,11 @@ class MenuHandler:
         else:
             self.window.options_overlay.show()
             self.window.options_overlay.raise_()
+            self.window.menu_overlay.hide()
 
     def close_options(self) -> None:
         self.window.options_overlay.hide()
-        self.hide_control_buttons()
+        self.window.menu_overlay.hide()
 
     def toggle_developer_menu(self) -> None:
         if self.window.dev_menu.isVisible():
@@ -74,6 +77,7 @@ class MenuHandler:
         else:
             self.window.dev_menu.show()
             self.window.dev_menu.raise_()
+        self.window.menu_overlay.hide()
 
     def toggle_sound(self) -> None:
         if self.window.sound_overlay.isVisible():
@@ -81,10 +85,11 @@ class MenuHandler:
         else:
             self.window.sound_overlay.show()
             self.window.sound_overlay.raise_()
+            self.window.menu_overlay.hide()
 
     def close_sound(self) -> None:
         self.window.sound_overlay.hide()
-        self.hide_control_buttons()
+        self.window.menu_overlay.hide()
 
     def toggle_breath_modes(self) -> None:
         if self.window.breath_modes.isVisible():
@@ -92,15 +97,20 @@ class MenuHandler:
         else:
             self.window.breath_modes.show()
             self.window.breath_modes.raise_()
+            self.window.menu_overlay.hide()
 
     def close_breath_modes(self) -> None:
         self.window.breath_modes.hide()
-        self.hide_control_buttons()
+        self.window.menu_overlay.hide()
 
     def hide_control_buttons(self) -> None:
         for btn in self.window.control_buttons:
             btn.hide()
+        if hasattr(self.window, "menu_overlay"):
+            self.window.menu_overlay.hide()
 
     def show_control_buttons(self) -> None:
         for btn in self.window.control_buttons:
             btn.show()
+        if hasattr(self.window, "menu_overlay"):
+            self.window.menu_overlay.show_with_anim()

--- a/calmio/menu_overlay.py
+++ b/calmio/menu_overlay.py
@@ -1,0 +1,118 @@
+from PySide6.QtCore import Qt, Signal, QPropertyAnimation
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QLabel,
+    QGridLayout,
+    QGraphicsOpacityEffect,
+)
+
+
+class MenuOverlay(QWidget):
+    """Floating modal menu with glass style."""
+
+    breath_modes_requested = Signal()
+    sound_requested = Signal()
+    stats_requested = Signal()
+    end_requested = Signal()
+    achievements_requested = Signal()
+    settings_requested = Signal()
+    developer_requested = Signal()
+    close_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setWindowFlags(Qt.Popup)
+        self.setStyleSheet(
+            "background:rgba(255,255,255,0.8);border-radius:24px;color:#444;"
+        )
+
+        self.opacity = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(10)
+
+        header = QHBoxLayout()
+        self.back_btn = QPushButton("\u2190")
+        self.back_btn.setStyleSheet(
+            "QPushButton{background:none;border:none;font-size:18px;}"
+        )
+        self.back_btn.clicked.connect(self.hide_with_anim)
+        header.addWidget(self.back_btn, alignment=Qt.AlignLeft)
+        header.addStretch()
+        layout.addLayout(header)
+
+        self.grid = QGridLayout()
+        self.grid.setSpacing(15)
+        layout.addLayout(self.grid)
+        layout.addStretch()
+
+        self.buttons = []
+        self._add_button(0, 0, "\U0001FAC1", "Respiraciones", self.breath_modes_requested)
+        self._add_button(0, 1, "\U0001F3B5", "Sonido", self.sound_requested)
+        self._add_button(1, 0, "\U0001F4CA", "Estad\u00edsticas", self.stats_requested)
+        self._add_button(1, 1, "\U0001F534", "Terminar sesi\u00f3n", self.end_requested)
+        self._add_button(2, 0, "\U0001F9E0", "Logros", self.achievements_requested)
+        self._add_button(2, 1, "\u2699\ufe0f", "Ajustes", self.settings_requested)
+        self._add_button(3, 0, "\U0001F41B", "Modo desarrollador", self.developer_requested, span=2)
+
+    def _add_button(self, row, col, icon, text, signal, span=1):
+        btn = QPushButton()
+        btn.setCursor(Qt.PointingHandCursor)
+        btn.setStyleSheet(
+            "QPushButton{background:rgba(255,255,255,0.6);border:none;border-radius:12px;}"
+            "QPushButton:hover{background:rgba(255,255,255,0.8);}"
+        )
+        b_layout = QVBoxLayout(btn)
+        b_layout.setContentsMargins(10, 10, 10, 10)
+        icon_lbl = QLabel(icon)
+        icon_lbl.setAlignment(Qt.AlignCenter)
+        icon_lbl.setStyleSheet("font-size:32px;")
+        txt_lbl = QLabel(text)
+        txt_lbl.setAlignment(Qt.AlignCenter)
+        txt_lbl.setWordWrap(True)
+        txt_lbl.setStyleSheet("font-size:16px;")
+        b_layout.addWidget(icon_lbl)
+        b_layout.addWidget(txt_lbl)
+        btn.clicked.connect(signal.emit)
+        if span == 1:
+            self.grid.addWidget(btn, row, col)
+        else:
+            self.grid.addWidget(btn, row, col, 1, span)
+        self.buttons.append(btn)
+
+    def adjust_position(self):
+        if not self.parent():
+            return
+        pw = self.parent().width()
+        ph = self.parent().height()
+        w = int(pw * 0.8)
+        h = int(ph * 0.6)
+        self.setGeometry((pw - w) // 2, (ph - h) // 2, w, h)
+
+    def show_with_anim(self):
+        self.adjust_position()
+        self.opacity.setOpacity(0)
+        super().show()
+        anim = QPropertyAnimation(self.opacity, b"opacity", self)
+        anim.setDuration(200)
+        anim.setStartValue(0)
+        anim.setEndValue(1)
+        anim.start()
+        self._anim = anim
+
+    def hide_with_anim(self):
+        anim = QPropertyAnimation(self.opacity, b"opacity", self)
+        anim.setDuration(200)
+        anim.setStartValue(1)
+        anim.setEndValue(0)
+        anim.finished.connect(super().hide)
+        anim.finished.connect(self.close_requested)
+        anim.start()
+        self._anim = anim


### PR DESCRIPTION
## Summary
- add a new `MenuOverlay` widget with semi transparent background and fade animations
- integrate the modal into `MainWindow` replacing the old icon menu
- update `MenuHandler` to show/hide the new overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475e22256c832ba8e93058dda7cabc