### PR TITLE
Replace old icon menu with modal glass menu

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -186,32 +186,13 @@ class MainWindow(QMainWindow):
 
         self.setFocus()
 
-        self.options_button = QPushButton("\u2699\ufe0f", self)
-        self.stats_button = QPushButton("\ud83d\udcca", self)
-        self.end_button = QPushButton("\U0001F6D1", self)
-        self.dev_button = QPushButton("\U0001F41B", self)
-        self.sound_button = QPushButton("\U0001F3B5", self)
-        self.patterns_button = QPushButton("\U0001FAC2", self)
 
-        self.control_buttons = [
-            self.options_button,
-            self.stats_button,
-            self.end_button,
-            self.dev_button,
-            self.sound_button,
-            self.patterns_button,
-        ]
-        for btn in self.control_buttons:
-            self._setup_control_button(btn)
-
-        self.end_button.clicked.connect(self.session_manager.end_session)
 
         self.menu_button.setFocusPolicy(Qt.NoFocus)
 
         self.stats_overlay = StatsOverlay(self)
         self.stats_overlay.setGeometry(self.rect())
         self.stats_overlay.hide()
-        self.stats_button.clicked.connect(self.overlay_manager.toggle_stats)
         self.stats_overlay.view_sessions.connect(self.overlay_manager.open_today_sessions)
         self.stats_overlay.session_requested.connect(self.overlay_manager.open_session_details)
         self.stats_overlay.view_badges_today.connect(self.overlay_manager.open_today_badges)
@@ -238,12 +219,10 @@ class MainWindow(QMainWindow):
         self.options_overlay.setGeometry(self.rect())
         self.options_overlay.hide()
         self.options_overlay.back_requested.connect(self.menu_handler.close_options)
-        self.options_button.clicked.connect(self.menu_handler.toggle_options)
         self.dev_menu = DeveloperOverlay(self)
         self.dev_menu.hide()
         self.dev_menu.speed_toggled.connect(self.session_manager.toggle_developer_speed)
         self.dev_menu.next_day_requested.connect(self.session_manager.advance_day)
-        self.dev_button.clicked.connect(self.menu_handler.toggle_developer_menu)
 
         self.sound_overlay = SoundOverlay(self)
         self.sound_overlay.setGeometry(self.rect())
@@ -260,14 +239,12 @@ class MainWindow(QMainWindow):
         self.sound_overlay.music_mode_changed.connect(self.sound_manager.set_music_mode)
         self.sound_overlay.scale_changed.connect(self.sound_manager.set_scale_type)
         self.sound_overlay.breath_volume_toggled.connect(self.sound_manager.set_breath_volume_enabled)
-        self.sound_button.clicked.connect(self.menu_handler.toggle_sound)
 
         self.breath_modes = BreathModesOverlay(self)
         self.breath_modes.setGeometry(self.rect())
         self.breath_modes.hide()
         self.breath_modes.back_requested.connect(self.menu_handler.close_breath_modes)
         self.breath_modes.pattern_selected.connect(self._on_pattern_selected)
-        self.patterns_button.clicked.connect(self.menu_handler.toggle_breath_modes)
 
         self.menu_overlay = MenuOverlay(self)
         self.menu_overlay.hide()
@@ -445,10 +422,6 @@ class MainWindow(QMainWindow):
             if not (
                 self.menu_button.geometry().contains(pos)
                 or self.menu_overlay.geometry().contains(pos)
-                or self.options_button.geometry().contains(pos)
-                or self.stats_button.geometry().contains(pos)
-                or self.end_button.geometry().contains(pos)
-                or self.dev_button.geometry().contains(pos)
                 or self.dev_menu.geometry().contains(pos)
                 or self.stats_overlay.geometry().contains(pos)
                 or self.today_sessions.geometry().contains(pos)
@@ -495,10 +468,6 @@ class MainWindow(QMainWindow):
         if not (
             self.menu_button.geometry().contains(pos)
             or self.menu_overlay.geometry().contains(pos)
-            or self.options_button.geometry().contains(pos)
-            or self.stats_button.geometry().contains(pos)
-            or self.end_button.geometry().contains(pos)
-            or self.dev_button.geometry().contains(pos)
             or self.dev_menu.geometry().contains(pos)
             or self.stats_overlay.geometry().contains(pos)
             or self.today_sessions.geometry().contains(pos)
@@ -590,14 +559,9 @@ class MainWindow(QMainWindow):
     def update_speed(self):
         self.session_manager.update_speed()
 
-    def _setup_control_button(self, button: QPushButton) -> None:
-        self.menu_handler._setup_control_button(button)
 
     def hide_control_buttons(self) -> None:
         self.menu_handler.hide_control_buttons()
-
-    def show_control_buttons(self) -> None:
-        self.menu_handler.show_control_buttons()
 
     def toggle_breath_modes(self) -> None:
         self.menu_handler.toggle_breath_modes()

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -1,5 +1,4 @@
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QPushButton
 
 
 class MenuHandler:
@@ -15,22 +14,10 @@ class MenuHandler:
         x = self.window.width() - self.window.menu_button.width() - margin
         y = self.window.height() - self.window.menu_button.height() - margin
         self.window.menu_button.move(x, y)
-        buttons = [
-            self.window.options_button,
-            self.window.stats_button,
-            self.window.end_button,
-            self.window.dev_button,
-        ]
-        if hasattr(self.window, "sound_button"):
-            buttons.append(self.window.sound_button)
-        if hasattr(self.window, "patterns_button"):
-            buttons.append(self.window.patterns_button)
-        for i, btn in enumerate(buttons, start=1):
-            btn.move(x - i * (self.window.menu_button.width() + margin), y)
         if hasattr(self.window, "dev_menu"):
             self.window.dev_menu.move(
-                self.window.dev_button.x() - self.window.dev_menu.width() + self.window.dev_button.width(),
-                self.window.dev_button.y() - self.window.dev_menu.height() - margin,
+                x - self.window.dev_menu.width() + self.window.menu_button.width(),
+                y - self.window.dev_menu.height() - margin,
             )
         if hasattr(self.window, "menu_overlay"):
             self.window.menu_overlay.adjust_position()
@@ -44,12 +31,6 @@ class MenuHandler:
         if hasattr(self.window, "breath_modes"):
             self.window.breath_modes.setGeometry(self.window.rect())
 
-    def _setup_control_button(self, button: QPushButton) -> None:
-        """Apply common styling to control buttons."""
-        button.setFixedSize(40, 40)
-        button.setStyleSheet("QPushButton {background:none; border:none; font-size:20px;}")
-        button.setFocusPolicy(Qt.NoFocus)
-        button.hide()
 
     # --- visibility toggles --------------------------------------------
     def toggle_menu(self) -> None:
@@ -104,13 +85,6 @@ class MenuHandler:
         self.window.menu_overlay.hide()
 
     def hide_control_buttons(self) -> None:
-        for btn in self.window.control_buttons:
-            btn.hide()
         if hasattr(self.window, "menu_overlay"):
             self.window.menu_overlay.hide()
 
-    def show_control_buttons(self) -> None:
-        for btn in self.window.control_buttons:
-            btn.show()
-        if hasattr(self.window, "menu_overlay"):
-            self.window.menu_overlay.show_with_anim()


### PR DESCRIPTION
## Summary
- remove deprecated bottom icon menu controls
- keep modal glass-style menu overlay as the only main menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476db7674c832b8ef98b0fe2d32ad0