### PR TITLE
Fix QFont initialization

### DIFF
--- a/calmio/font_utils.py
+++ b/calmio/font_utils.py
@@ -7,5 +7,9 @@ def get_emoji_font(size: int = 12) -> QFont:
     families = set(QFontDatabase().families())
     for fam in preferred:
         if fam in families:
-            return QFont(fam, point_size=size)
-    return QFont("Sans Serif", point_size=size)
+            font = QFont(fam)
+            font.setPointSize(size)
+            return font
+    font = QFont("Sans Serif")
+    font.setPointSize(size)
+    return font


### PR DESCRIPTION
## Summary
- avoid using unsupported keyword argument in `get_emoji_font`
- adjust the font size using `setPointSize`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684773c54cd4832b8d25d510c0f372c1