### PR TITLE
Fix painter warnings on menu

### DIFF
--- a/calmio/animated_background.py
+++ b/calmio/animated_background.py
@@ -158,6 +158,8 @@ class AnimatedBackground(QWidget):
 
     def paintEvent(self, event):
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         rect = self.rect()
         painter.fillRect(rect, QColor("white"))
         if self._opacity <= 0:

--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -128,6 +128,8 @@ class BreathCircle(QWidget):
         if self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         painter.setRenderHint(QPainter.Antialiasing)
         center = self.rect().center()
 

--- a/calmio/monthly_stats.py
+++ b/calmio/monthly_stats.py
@@ -25,6 +25,8 @@ class MonthlyLineGraph(QWidget):
         if not self.minutes or self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         painter.setRenderHint(QPainter.Antialiasing)
         w = self.width()
         h = self.height()
@@ -106,6 +108,8 @@ class DonutProgress(QWidget):
         if self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         painter.setRenderHint(QPainter.Antialiasing)
         stroke = 10
         side = min(self.width(), self.height()) - stroke

--- a/calmio/progress_circle.py
+++ b/calmio/progress_circle.py
@@ -19,6 +19,8 @@ class ProgressCircle(QWidget):
         if self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         painter.setRenderHint(QPainter.Antialiasing)
         rect = self.rect().adjusted(20, 20, -20, -20)
 

--- a/calmio/session_details.py
+++ b/calmio/session_details.py
@@ -71,6 +71,8 @@ class BreathGraph(QWidget):
         if not self.values or self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         painter.setRenderHint(QPainter.Antialiasing)
 
         margin_x = 40

--- a/calmio/wave_overlay.py
+++ b/calmio/wave_overlay.py
@@ -89,6 +89,8 @@ class WaveOverlay(QWidget):
         if not self._waves:
             return
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         painter.setRenderHint(QPainter.Antialiasing)
         for wave in list(self._waves):
             if wave._opacity <= 0:

--- a/calmio/weekly_stats.py
+++ b/calmio/weekly_stats.py
@@ -32,6 +32,8 @@ class WeeklyBarGraph(QWidget):
         if self.width() <= 0 or self.height() <= 0:
             return
         painter = QPainter(self)
+        if not painter.isActive():
+            return
         painter.setRenderHint(QPainter.Antialiasing)
 
         w = self.width()


### PR DESCRIPTION
## Summary
- guard all paint events with `painter.isActive()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477d83c528832b9b4377efecc3d516