### PR TITLE
Fix QPainter lifecycle in widgets

### DIFF
--- a/calmio/animated_background.py
+++ b/calmio/animated_background.py
@@ -202,4 +202,5 @@ class AnimatedBackground(QWidget):
             path.closeSubpath()
             color = QColor(255, 255, 255, 80)
             painter.fillPath(path, color)
+        painter.end()
 

--- a/calmio/breath_circle.py
+++ b/calmio/breath_circle.py
@@ -158,6 +158,7 @@ class BreathCircle(QWidget):
         painter.setBrush(QBrush(gradient))
         painter.setPen(Qt.NoPen)
         painter.drawEllipse(center, self._radius, self._radius)
+        painter.end()
 
     def start_inhale(self, color=None, duration=None, end_radius=None):
         if self.phase not in ('idle', 'holding'):

--- a/calmio/monthly_stats.py
+++ b/calmio/monthly_stats.py
@@ -84,7 +84,7 @@ class MonthlyLineGraph(QWidget):
                 Qt.AlignHCenter | Qt.AlignTop,
                 self.labels[i] if i < len(self.labels) else f"Week {i+1}",
             )
-
+        painter.end()
 
 class DonutProgress(QWidget):
     """Circular progress bar for monthly goal."""
@@ -133,6 +133,7 @@ class DonutProgress(QWidget):
         painter.setPen(QColor("#444"))
         center_text = f"{int(self.minutes)}\n/{int(self.goal)} min"
         painter.drawText(self.rect(), Qt.AlignCenter, center_text)
+        painter.end()
 
 
 class MonthlyStatsView(QWidget):

--- a/calmio/progress_circle.py
+++ b/calmio/progress_circle.py
@@ -91,3 +91,4 @@ class ProgressCircle(QWidget):
             rect.bottom() + 15,
             f"{labels['left']} min",
         )
+        painter.end()

--- a/calmio/session_details.py
+++ b/calmio/session_details.py
@@ -114,6 +114,7 @@ class BreathGraph(QWidget):
         painter.setPen(QColor("#555"))
         painter.drawText(points[0].x() - 20, points[0].y() - 5, self.start_label)
         painter.drawText(points[-1].x() - 30, points[-1].y() - 5, self.end_label)
+        painter.end()
 
 
 class SessionDetailsView(QWidget):

--- a/calmio/wave_overlay.py
+++ b/calmio/wave_overlay.py
@@ -103,5 +103,5 @@ class WaveOverlay(QWidget):
             painter.setPen(pen)
             painter.setBrush(Qt.NoBrush)
             painter.drawEllipse(self._center, int(wave._radius), int(wave._radius))
-
+        painter.end()
 

--- a/calmio/weekly_stats.py
+++ b/calmio/weekly_stats.py
@@ -68,7 +68,7 @@ class WeeklyBarGraph(QWidget):
                 Qt.AlignHCenter | Qt.AlignTop,
                 self.days[i],
             )
-
+        painter.end()
 
 class WeeklyStatsView(QWidget):
     """Widget displaying weekly statistics."""


### PR DESCRIPTION
## Summary
- ensure every QPainter object is properly ended
- clean up painter usage in all custom paint events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684852875ab8832ba7cf7c854547004a