### PR TITLE
Simplify modal menu to avoid QPainter errors

### DIFF
--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -15,6 +15,7 @@ from .main_window import MainWindow
 from .animated_background import AnimatedBackground
 from .wave_overlay import WaveOverlay
 from .menu_handler import MenuHandler
+from .glass_menu import GlassMenu
 from .session_manager import SessionManager
 from .overlay_manager import OverlayManager
 from .message_utils import MessageHandler
@@ -34,6 +35,7 @@ __all__ = [
     "AnimatedBackground",
     "WaveOverlay",
     "MenuHandler",
+    "GlassMenu",
     "SessionManager",
     "OverlayManager",
     "MessageHandler",

--- a/calmio/glass_menu.py
+++ b/calmio/glass_menu.py
@@ -7,17 +7,16 @@ from PySide6.QtWidgets import (
     QPushButton,
     QLabel,
     QGraphicsOpacityEffect,
-    QScrollArea,
     QFrame,
     QSizePolicy,
     QGraphicsDropShadowEffect,
-    QLayout,
 )
+
 from .font_utils import get_emoji_font
 
 
-class MenuOverlay(QWidget):
-    """Floating modal menu with glass style."""
+class GlassMenu(QWidget):
+    """Minimal floating menu with a glass style background."""
 
     breath_modes_requested = Signal()
     sound_requested = Signal()
@@ -40,21 +39,8 @@ class MenuOverlay(QWidget):
         self.opacity.setOpacity(1)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
-
-        self.scroll = QScrollArea()
-        self.scroll.setWidgetResizable(True)
-        self.scroll.setStyleSheet("QScrollArea{border:none;}")
-        self.scroll.setFrameShape(QFrame.NoFrame)
-        layout.addWidget(self.scroll)
-
-        container = QWidget()
-        self.scroll.setWidget(container)
-        c_layout = QVBoxLayout(container)
-        c_layout.setContentsMargins(20, 20, 20, 20)
-        c_layout.setSpacing(15)
-        c_layout.setSizeConstraint(QLayout.SetMinimumSize)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(15)
 
         header = QHBoxLayout()
         self.back_btn = QPushButton("\u2190")
@@ -72,13 +58,7 @@ class MenuOverlay(QWidget):
         title.setAlignment(Qt.AlignCenter)
         header.addWidget(title, alignment=Qt.AlignCenter)
         header.addStretch()
-        c_layout.addLayout(header)
-
-        self.menu_container = QVBoxLayout()
-        self.menu_container.setSpacing(10)
-        self.menu_container.setSizeConstraint(QLayout.SetMinimumSize)
-        c_layout.addLayout(self.menu_container)
-        c_layout.addStretch()
+        layout.addLayout(header)
 
         self.cards = []
         self.labels = []
@@ -89,6 +69,7 @@ class MenuOverlay(QWidget):
         self._add_menu_row("\U0001F9E0", "Logros", self.achievements_requested)
         self._add_menu_row("\u2699\ufe0f", "Ajustes", self.settings_requested)
         self._add_menu_row("\U0001F41B", "Modo desarrollador", self.developer_requested)
+        layout.addStretch()
 
     def _add_menu_row(self, icon: str, text: str, signal: Signal) -> None:
         card = QFrame()
@@ -123,7 +104,7 @@ class MenuOverlay(QWidget):
 
         card.mouseReleaseEvent = lambda e, s=signal: s.emit()
 
-        self.menu_container.addWidget(card)
+        self.layout().addWidget(card)
         self.cards.append(card)
         self.labels.append(txt_lbl)
 

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -39,7 +39,7 @@ from .data_store import DataStore
 from .animated_background import AnimatedBackground
 from .wave_overlay import WaveOverlay
 from .menu_handler import MenuHandler
-from .menu_overlay import MenuOverlay
+from .glass_menu import GlassMenu
 from .session_manager import SessionManager
 from .overlay_manager import OverlayManager
 from .message_utils import MessageHandler
@@ -246,7 +246,7 @@ class MainWindow(QMainWindow):
         self.breath_modes.back_requested.connect(self.menu_handler.close_breath_modes)
         self.breath_modes.pattern_selected.connect(self._on_pattern_selected)
 
-        self.menu_overlay = MenuOverlay(self)
+        self.menu_overlay = GlassMenu(self)
         self.menu_overlay.hide()
         self.menu_overlay.breath_modes_requested.connect(self.menu_handler.toggle_breath_modes)
         self.menu_overlay.sound_requested.connect(self.menu_handler.toggle_sound)


### PR DESCRIPTION
## Summary
- replace `MenuOverlay` with a new `GlassMenu` widget that doesn't use custom painting
- update `MainWindow` to use the new menu
- export `GlassMenu` from `calmio/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684855be7a84832baa86824bd94a5b4c