### PR TITLE
Add daily challenge prompt widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ En Windows puede ejecutarse `run_app.bat`, el script creará un entorno virtual 
   - El usuario puede pulsar el círculo o mantener la barra espaciadora para respirar.
   - Cada ciclo incrementa el contador visual en la parte superior.
   - Mensajes motivacionales aparecen cada cierto número de respiraciones.
+  - Un botón flotante 🏆 abre el **Reto diario** cuando está disponible. El botón se desvanece al comenzar una sesión o al cerrar el reto.
 
 ## Menú y controles
 

--- a/calmio/__init__.py
+++ b/calmio/__init__.py
@@ -6,6 +6,7 @@ from .stats_overlay import StatsOverlay
 from .session_complete import SessionComplete
 from .biofeedback_overlay import BioFeedbackOverlay
 from .daily_challenge_overlay import DailyChallengeOverlay
+from .daily_challenge_prompt import DailyChallengePrompt
 from .today_sessions import TodaySessionsView
 from .session_details import SessionDetailsView
 from .options_overlay import OptionsOverlay
@@ -42,4 +43,5 @@ __all__ = [
     "SoundManager",
     "BioFeedbackOverlay",
     "DailyChallengeOverlay",
+    "DailyChallengePrompt",
 ]

--- a/calmio/daily_challenge_prompt.py
+++ b/calmio/daily_challenge_prompt.py
@@ -1,0 +1,38 @@
+from PySide6.QtCore import Qt, Signal, QPropertyAnimation
+from PySide6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QGraphicsOpacityEffect
+
+
+class DailyChallengePrompt(QWidget):
+    """Small floating button prompting to open the daily challenge."""
+
+    clicked = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, False)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.button = QPushButton("\U0001F3C6")
+        self.button.setFixedSize(48, 48)
+        self.button.setStyleSheet(
+            "QPushButton{background-color:#4D9FFF;border:none;border-radius:24px;color:white;font-size:20px;}"
+        )
+        self.button.clicked.connect(self.clicked)
+        layout.addWidget(self.button)
+
+        self.opacity = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity)
+        self.opacity.setOpacity(1.0)
+        self._fade = None
+
+    def fade_out(self):
+        if self._fade and self._fade.state() != QPropertyAnimation.Stopped:
+            self._fade.stop()
+        self._fade = QPropertyAnimation(self.opacity, b"opacity", self)
+        self._fade.setDuration(600)
+        self._fade.setStartValue(self.opacity.opacity())
+        self._fade.setEndValue(0)
+        self._fade.finished.connect(self.hide)
+        self._fade.start()

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -46,6 +46,7 @@ from .message_utils import MessageHandler
 from .sound_manager import SoundManager
 from .biofeedback_overlay import BioFeedbackOverlay
 from .daily_challenge_overlay import DailyChallengeOverlay
+from .daily_challenge_prompt import DailyChallengePrompt
 
 
 class MainWindow(QMainWindow):
@@ -434,6 +435,10 @@ class MainWindow(QMainWindow):
                     hasattr(self, "daily_challenge_overlay")
                     and self.daily_challenge_overlay.geometry().contains(pos)
                 )
+                or (
+                    hasattr(self, "daily_challenge_prompt")
+                    and self.daily_challenge_prompt.geometry().contains(pos)
+                )
                 ):
                 self.menu_handler.hide_control_buttons()
                 self.dev_menu.hide()
@@ -479,6 +484,10 @@ class MainWindow(QMainWindow):
             or (
                 hasattr(self, "daily_challenge_overlay")
                 and self.daily_challenge_overlay.geometry().contains(pos)
+            )
+            or (
+                hasattr(self, "daily_challenge_prompt")
+                and self.daily_challenge_prompt.geometry().contains(pos)
             )
         ):
             self.menu_handler.hide_control_buttons()
@@ -534,6 +543,10 @@ class MainWindow(QMainWindow):
 
     def stop_prompt_animation(self):
         self.message_handler.stop_prompt_animation()
+
+    def hide_daily_challenge_prompt(self):
+        if hasattr(self, "daily_challenge_prompt") and self.daily_challenge_prompt.isVisible():
+            self.daily_challenge_prompt.fade_out()
 
     def display_motivational_message(self, text):
         self.message_handler.display_motivational_message(text)
@@ -616,10 +629,16 @@ class MainWindow(QMainWindow):
         self.daily_challenge_overlay.closed.connect(
             self.overlay_manager.close_daily_challenge
         )
+
+        self.daily_challenge_prompt = DailyChallengePrompt(self)
+        self.daily_challenge_prompt.hide()
+        self.daily_challenge_prompt.clicked.connect(
+            self.overlay_manager.show_daily_challenge
+        )
+        self.menu_handler.position_buttons()
+
         if not today_ch.get("completed"):
-            QTimer.singleShot(
-                1500, self.overlay_manager.show_daily_challenge
-            )
+            QTimer.singleShot(1500, self.daily_challenge_prompt.show)
 
     def show_biofeedback_message(self):
         if not self.biofeedback_messages:
@@ -634,4 +653,5 @@ class MainWindow(QMainWindow):
 
     def _challenge_completed(self):
         self.data_store.mark_challenge_completed()
+        self.hide_daily_challenge_prompt()
         self.display_motivational_message("\u2728 Reto diario completado!")

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -30,6 +30,10 @@ class MenuHandler:
             self.window.sound_overlay.setGeometry(self.window.rect())
         if hasattr(self.window, "breath_modes"):
             self.window.breath_modes.setGeometry(self.window.rect())
+        if hasattr(self.window, "daily_challenge_prompt"):
+            px = margin
+            py = self.window.height() - self.window.daily_challenge_prompt.height() - margin
+            self.window.daily_challenge_prompt.move(px, py)
 
 
     # --- visibility toggles --------------------------------------------

--- a/calmio/overlay_manager.py
+++ b/calmio/overlay_manager.py
@@ -107,3 +107,5 @@ class OverlayManager:
     def close_daily_challenge(self):
         if hasattr(self.window, "daily_challenge_overlay"):
             self.window.daily_challenge_overlay.hide()
+        if hasattr(self.window, "hide_daily_challenge_prompt"):
+            self.window.hide_daily_challenge_prompt()

--- a/calmio/session_manager.py
+++ b/calmio/session_manager.py
@@ -27,6 +27,8 @@ class SessionManager:
             self.window.session_seconds = 0
             self.window.cycle_durations = []
             self.window.stop_prompt_animation()
+            if hasattr(self.window, "hide_daily_challenge_prompt"):
+                self.window.hide_daily_challenge_prompt()
             self.window._chakra_index = 0
             if hasattr(self.window, "bg"):
                 self.window.bg.transition_to_index(0, duration=0)


### PR DESCRIPTION
## Summary
- create `DailyChallengePrompt` floating button with fade-out animation
- position the new prompt via `MenuHandler`
- connect the prompt to open the daily challenge overlay
- hide the prompt when the daily challenge is closed or completed
- fade out the prompt on session start
- update README with new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848921b1db8832bad9ea1517c17aff8