### PR TITLE
Ensure daily challenge overlay hidden by default

### DIFF
--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -629,6 +629,8 @@ class MainWindow(QMainWindow):
         self.daily_challenge_overlay.closed.connect(
             self.overlay_manager.close_daily_challenge
         )
+        # Keep the overlay hidden until explicitly shown via the manager
+        self.daily_challenge_overlay.hide()
 
         self.daily_challenge_prompt = DailyChallengePrompt(self)
         self.daily_challenge_prompt.hide()

--- a/tests/test_daily_challenge_ui.py
+++ b/tests/test_daily_challenge_ui.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from pathlib import Path
+import platformdirs
+from PySide6.QtWidgets import QApplication
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from calmio.main_window import MainWindow
+
+
+def test_daily_challenge_overlay_visibility(tmp_path, monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    monkeypatch.setattr(platformdirs, "user_data_dir", lambda *a, **k: str(tmp_path))
+    app = QApplication.instance() or QApplication([])
+    window = MainWindow()
+    window.show()
+    overlay = window.daily_challenge_overlay
+    assert overlay is not None
+    # Overlay should start hidden
+    assert not overlay.isVisible()
+    window.overlay_manager.show_daily_challenge()
+    app.processEvents()
+    assert overlay.isVisible()
+    window.overlay_manager.close_daily_challenge()
+    assert not overlay.isVisible()
+    app.quit()


### PR DESCRIPTION
## Summary
- hide `DailyChallengeOverlay` after wiring signals so it only appears when explicitly shown
- test overlay visibility is controlled by `overlay_manager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848957bec58832bb637b6b95e024f25