### PR TITLE
Improve daily challenge prompt behaviour

### DIFF
--- a/calmio/daily_challenge_prompt.py
+++ b/calmio/daily_challenge_prompt.py
@@ -15,9 +15,16 @@ class DailyChallengePrompt(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         self.button = QPushButton("\U0001F3C6")
-        self.button.setFixedSize(48, 48)
+        # Slightly smaller circular button
+        self.button.setFixedSize(40, 40)
         self.button.setStyleSheet(
-            "QPushButton{background-color:#4D9FFF;border:none;border-radius:24px;color:white;font-size:20px;}"
+            "QPushButton{"
+            "background-color:#4D9FFF;"
+            "border:none;"
+            "border-radius:20px;"
+            "color:white;"
+            "font-size:20px;"
+            "}"
         )
         self.button.clicked.connect(self.clicked)
         layout.addWidget(self.button)
@@ -31,7 +38,8 @@ class DailyChallengePrompt(QWidget):
         if self._fade and self._fade.state() != QPropertyAnimation.Stopped:
             self._fade.stop()
         self._fade = QPropertyAnimation(self.opacity, b"opacity", self)
-        self._fade.setDuration(600)
+        # Match the fade duration of the motivational text
+        self._fade.setDuration(4000)
         self._fade.setStartValue(self.opacity.opacity())
         self._fade.setEndValue(0)
         self._fade.finished.connect(self.hide)

--- a/calmio/main_window.py
+++ b/calmio/main_window.py
@@ -640,7 +640,8 @@ class MainWindow(QMainWindow):
         self.menu_handler.position_buttons()
 
         if not today_ch.get("completed"):
-            QTimer.singleShot(1500, self.daily_challenge_prompt.show)
+            # Show the prompt immediately once the challenge is set up
+            self.daily_challenge_prompt.show()
 
     def show_biofeedback_message(self):
         if not self.biofeedback_messages:

--- a/calmio/menu_handler.py
+++ b/calmio/menu_handler.py
@@ -31,8 +31,17 @@ class MenuHandler:
         if hasattr(self.window, "breath_modes"):
             self.window.breath_modes.setGeometry(self.window.rect())
         if hasattr(self.window, "daily_challenge_prompt"):
-            px = margin
-            py = self.window.height() - self.window.daily_challenge_prompt.height() - margin
+            # Position the daily challenge prompt in the bottom-right corner
+            px = (
+                self.window.width()
+                - self.window.daily_challenge_prompt.width()
+                - margin
+            )
+            py = (
+                self.window.height()
+                - self.window.daily_challenge_prompt.height()
+                - margin
+            )
             self.window.daily_challenge_prompt.move(px, py)
 
 


### PR DESCRIPTION
## Summary
- show daily challenge prompt without delay
- position the prompt in the bottom-right corner
- reduce the prompt button size and keep it round
- slow down fade-out animation for the prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684899635a18832bbd58ac245d9b2fbb